### PR TITLE
feat: showcase CLI and MCP server on the landing page

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -15,6 +15,7 @@ import { DiagramFullscreenModal } from "./components/DiagramFullscreenModal";
 import { Hero } from "./components/Hero";
 import { FeatureCards } from "./components/FeatureCards";
 import { HowItWorks, Security, OpenSource, FaqSection } from "./components/LandingSections";
+import { DevTools } from "./components/DevToolsSection";
 import {
   GITHUB_TOKEN_LOCAL_STORAGE_KEY,
   REPO_URL_LOCAL_STORAGE_KEY,
@@ -1299,6 +1300,7 @@ const App: React.FC = () => {
         )}
 
         <div className={showOutputArea ? "mt-16 sm:mt-20" : ""}>
+          <DevTools />
           <HowItWorks />
           <Security />
           <OpenSource />
@@ -1329,6 +1331,20 @@ const App: React.FC = () => {
             className="hover:text-slate-300 transition-colors"
           >
             GitHub
+          </a>
+          <a
+            href="https://www.npmjs.com/package/gitscape"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-slate-300 transition-colors"
+          >
+            CLI on npm
+          </a>
+          <a
+            href="#developer-tools"
+            className="hover:text-slate-300 transition-colors"
+          >
+            MCP server
           </a>
           <a
             href="/api/docs"

--- a/frontend/components/CodeSnippet.tsx
+++ b/frontend/components/CodeSnippet.tsx
@@ -1,0 +1,118 @@
+import React, { useCallback, useState } from "react";
+
+/**
+ * CodeSnippet — copy-to-clipboard code block matching the Security section's
+ * scan-report.json panel styling. Two variants: a full panel with an optional
+ * header bar, and a `compact` single-row pill for inline CTAs.
+ */
+
+type Accent = "violet" | "emerald" | "amber";
+
+const ACCENTS: Record<Accent, { border: string; text: string; bg: string }> = {
+  violet: { border: "rgba(139,92,246,0.35)", text: "#c4b5fd", bg: "rgba(139,92,246,0.08)" },
+  emerald: { border: "rgba(16,185,129,0.35)", text: "#6ee7b7", bg: "rgba(16,185,129,0.08)" },
+  amber: { border: "rgba(245,158,11,0.35)", text: "#fcd34d", bg: "rgba(245,158,11,0.08)" },
+};
+
+interface CodeSnippetProps {
+  /** Exact text written to the clipboard. */
+  code: string;
+  /** Optional header-bar label, e.g. ".mcp.json" or "terminal". */
+  title?: string;
+  /** Border tint + accent color. Defaults to neutral slate. */
+  accent?: Accent;
+  /** Render a non-copyable "$ " prefix for shell commands. */
+  prompt?: boolean;
+  /** Single-row pill variant for inline use (Hero, SkillExport upsell). */
+  compact?: boolean;
+  /** Optional syntax-tinted display override; falls back to plain {code}. */
+  children?: React.ReactNode;
+}
+
+const CopyButton: React.FC<{ code: string; accent?: Accent }> = ({ code, accent }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (_) { /* clipboard unavailable */ }
+  }, [code]);
+
+  return (
+    <button
+      onClick={handleCopy}
+      aria-label={copied ? "Copied" : "Copy to clipboard"}
+      title={copied ? "Copied" : "Copy to clipboard"}
+      className="flex items-center gap-1.5 shrink-0 px-2 py-1 rounded-md text-[11px] font-semibold transition-colors duration-150"
+      style={copied
+        ? { color: "#34d399", background: "rgba(16,185,129,0.12)" }
+        : { color: accent ? ACCENTS[accent].text : "#94a3b8", background: "transparent" }}
+    >
+      {copied ? (
+        <>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+          Copied
+        </>
+      ) : (
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+          <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+          <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+        </svg>
+      )}
+    </button>
+  );
+};
+
+export const CodeSnippet: React.FC<CodeSnippetProps> = ({
+  code,
+  title,
+  accent,
+  prompt = false,
+  compact = false,
+  children,
+}) => {
+  const borderColor = accent ? ACCENTS[accent].border : "rgba(71,85,105,0.5)";
+
+  if (compact) {
+    return (
+      <div
+        className="inline-flex items-center gap-2 max-w-full rounded-lg pl-3 pr-1 py-1.5 font-mono text-[12.5px]"
+        style={{ background: "#0b1220", border: `1px solid ${borderColor}` }}
+      >
+        <span className="overflow-x-auto whitespace-nowrap text-slate-200">
+          {prompt && <span className="text-slate-500 select-none">$ </span>}
+          {children ?? code}
+        </span>
+        <CopyButton code={code} accent={accent} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="rounded-[14px] overflow-hidden font-mono"
+      style={{ background: "#0b1220", border: `1px solid ${borderColor}` }}
+    >
+      {title != null && (
+        <div
+          className="flex items-center justify-between gap-2 pl-4.5 pr-2 py-2"
+          style={{ borderBottom: "1px solid rgba(71,85,105,0.4)", background: "rgba(15,23,42,0.8)" }}
+        >
+          <span className="text-xs text-slate-400">{title}</span>
+          <CopyButton code={code} accent={accent} />
+        </div>
+      )}
+      <div className="relative flex items-start gap-2 p-4.5">
+        <pre className="flex-1 m-0 overflow-x-auto text-[12.5px] leading-relaxed text-slate-200">
+          {prompt && <span className="text-slate-500 select-none">$ </span>}
+          {children ?? code}
+        </pre>
+        {title == null && <CopyButton code={code} accent={accent} />}
+      </div>
+    </div>
+  );
+};

--- a/frontend/components/DevToolsSection.tsx
+++ b/frontend/components/DevToolsSection.tsx
@@ -1,0 +1,189 @@
+import React, { useState } from "react";
+import { CodeSnippet } from "./CodeSnippet";
+import { CheckRow } from "./LandingSections";
+
+/**
+ * Developer tools section — CLI & MCP server showcase.
+ * Web = try it now, CLI = adopt it in your repo, MCP = agent-native.
+ */
+
+const MCP_URL = "https://gitscape-143600285956.us-central1.run.app/api/mcp";
+
+const MCP_JSON = `{
+  "mcpServers": {
+    "gitscape": {
+      "url": "${MCP_URL}"
+    }
+  }
+}`;
+
+type SurfaceKey = "cli" | "mcp" | "web";
+
+const SURFACES: { key: SurfaceKey; label: string; activeColor: string; underline: string }[] = [
+  { key: "cli", label: "Terminal", activeColor: "#c4b5fd", underline: "#7c3aed" },
+  { key: "mcp", label: "Your agent", activeColor: "#6ee7b7", underline: "#10b981" },
+  { key: "web", label: "Web", activeColor: "#fcd34d", underline: "#f59e0b" },
+];
+
+const CliPanel: React.FC = () => (
+  <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 items-center">
+    <div className="flex flex-col gap-4">
+      <h3 className="m-0 text-xl sm:text-2xl font-bold tracking-[-0.015em] text-slate-100">
+        One command. No install, no signup.
+      </h3>
+      <p className="m-0 text-[14.5px] leading-relaxed text-slate-400">
+        Point the CLI at any GitHub repository and it compiles the skill server-side,
+        then writes the files straight into your project — ready for your agent's next run.
+      </p>
+      <div className="flex flex-col gap-3 mt-1">
+        <CheckRow>Writes SKILL.md, manifest.json and references/ into <code className="font-mono text-[0.9em] text-slate-200">.agents/skills/&lt;owner-repo&gt;/</code></CheckRow>
+        <CheckRow>Auto-registers the skill in your AGENTS.md and CLAUDE.md</CheckRow>
+        <CheckRow><code className="font-mono text-[0.9em] text-slate-200">--token</code> for private repos · <code className="font-mono text-[0.9em] text-slate-200">--type framework</code> for engineering conventions</CheckRow>
+        <CheckRow>Zero dependencies · Node 18+ · MIT</CheckRow>
+      </div>
+      <a
+        href="https://www.npmjs.com/package/gitscape"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-[13px] font-semibold text-violet-400 hover:text-violet-300 transition-colors"
+      >
+        npm install -g gitscape if you'd rather keep it around →
+      </a>
+    </div>
+    <div className="flex flex-col gap-3">
+      <CodeSnippet
+        title="compile & install a skill"
+        accent="violet"
+        prompt
+        code="npx gitscape https://github.com/upstash/context7"
+      />
+      <CodeSnippet
+        title="uninstall"
+        accent="violet"
+        prompt
+        code="npx gitscape remove upstash-context7"
+      />
+    </div>
+  </div>
+);
+
+const McpPanel: React.FC = () => (
+  <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 items-center">
+    <div className="flex flex-col gap-4">
+      <h3 className="m-0 text-xl sm:text-2xl font-bold tracking-[-0.015em] text-slate-100">
+        Let your agent install skills for itself.
+      </h3>
+      <p className="m-0 text-[14.5px] leading-relaxed text-slate-400">
+        GitScape ships a hosted MCP server. Connect once, and your agent can compile
+        and install any repository as a skill — mid-conversation, no tab-switching.
+      </p>
+      <div className="flex flex-col gap-3 mt-1">
+        <CheckRow>One MCP tool — <code className="font-mono text-[0.9em] text-slate-200">install_skill</code> — compiles, scans and writes the skill into your workspace</CheckRow>
+        <CheckRow>Works in Claude Code, Cursor, Windsurf and Claude Desktop</CheckRow>
+        <CheckRow>Every skill passes ScapeGuard before it touches your repo</CheckRow>
+      </div>
+    </div>
+    <div className="flex flex-col gap-3">
+      <CodeSnippet
+        title="1 · point your agent at GitScape"
+        accent="emerald"
+        prompt
+        code="npx gitscape init"
+      />
+      <CodeSnippet title=".mcp.json" accent="emerald" code={MCP_JSON} />
+      <CodeSnippet
+        title="2 · then just ask"
+        accent="emerald"
+        code="Compile and install https://github.com/upstash/context7 as an agent skill"
+      />
+    </div>
+  </div>
+);
+
+const WebPanel: React.FC = () => (
+  <div className="flex flex-col items-center gap-5 text-center py-4">
+    <h3 className="m-0 text-xl sm:text-2xl font-bold tracking-[-0.015em] text-slate-100">
+      Or stay right here.
+    </h3>
+    <p className="m-0 text-[14.5px] leading-relaxed text-slate-400 max-w-[560px]">
+      Paste a GitHub URL above, watch the digest, map and skill compile in about a
+      minute, and download the scanned .zip. Same pipeline, zero setup.
+    </p>
+    <a
+      href="#digest-generator-input"
+      className="btn-shimmer inline-flex items-center px-6 py-3 rounded-[10px] text-sm font-bold transition-transform duration-200 hover:-translate-y-0.5"
+      style={{ background: "#f59e0b", color: "#0f172a" }}
+    >
+      Generate a skill now
+    </a>
+  </div>
+);
+
+export const DevTools: React.FC = () => {
+  const [active, setActive] = useState<SurfaceKey>("cli");
+
+  return (
+    <section
+      id="developer-tools"
+      className="px-6 sm:px-10 py-16 sm:py-[72px]"
+      style={{ borderTop: "1px solid rgba(71,85,105,0.25)" }}
+    >
+      <div className="max-w-[1100px] mx-auto flex flex-col gap-10">
+        <div className="flex flex-col items-center gap-2.5 text-center">
+          <span className="text-[11px] font-bold tracking-[0.1em] text-violet-400">CLI · MCP SERVER</span>
+          <h2 className="m-0 text-3xl sm:text-[38px] font-extrabold tracking-[-0.025em] text-slate-100">
+            Take GitScape into your workflow.
+          </h2>
+          <p className="m-0 text-[15px] text-slate-400 max-w-[640px]">
+            The web app is the demo. The CLI and MCP server are how you ship — compile any
+            repo into a skill from your terminal, or let your agent do it for you.
+          </p>
+        </div>
+
+        <div
+          className="rounded-2xl p-5 sm:p-7 flex flex-col gap-6"
+          style={{
+            background: "rgba(15,23,42,0.75)",
+            border: "1px solid rgba(71,85,105,0.5)",
+            boxShadow: "0 12px 48px -12px rgba(0,0,0,0.6)",
+          }}
+        >
+          <div
+            className="flex gap-1 overflow-x-auto"
+            style={{ borderBottom: "1px solid rgba(71,85,105,0.4)" }}
+            role="tablist"
+            aria-label="Ways to use GitScape"
+          >
+            {SURFACES.map((tab) => {
+              const isActive = active === tab.key;
+              return (
+                <button
+                  key={tab.key}
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => setActive(tab.key)}
+                  className={`px-4.5 py-2.5 text-[13px] whitespace-nowrap transition-colors duration-200 ${
+                    isActive ? "font-bold" : "font-semibold text-slate-400 hover:text-slate-200"
+                  }`}
+                  style={
+                    isActive
+                      ? { color: tab.activeColor, borderBottom: `2px solid ${tab.underline}`, marginBottom: -1 }
+                      : { borderBottom: "2px solid transparent", marginBottom: -1 }
+                  }
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <div role="tabpanel">
+            {active === "cli" && <CliPanel />}
+            {active === "mcp" && <McpPanel />}
+            {active === "web" && <WebPanel />}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -52,6 +52,7 @@ export const Header: React.FC<HeaderProps> = ({ onToggleTokenModal, hasToken }) 
         {/* Center nav */}
         <nav className="hidden md:flex items-center gap-7 text-[13px] font-medium text-slate-400">
           <a href="#how-it-works" className="hover:text-slate-200 transition-colors">How it works</a>
+          <a href="#developer-tools" className="hover:text-slate-200 transition-colors">CLI &amp; MCP</a>
           <a href="#security" className="hover:text-slate-200 transition-colors">Security</a>
           <a href="#open-source" className="hover:text-slate-200 transition-colors">Open source</a>
           <a

--- a/frontend/components/Hero.tsx
+++ b/frontend/components/Hero.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { CodeSnippet } from "./CodeSnippet";
 
 /**
  * Aurora hero — replaces the old centered h1/p block in App.tsx.
@@ -31,6 +32,16 @@ export const Hero: React.FC = () => (
         </code>{" "}
         — so your agents act like they wrote it.
       </p>
+
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <CodeSnippet compact prompt accent="violet" code="npx gitscape <repo-url>" />
+        <a
+          href="#developer-tools"
+          className="text-[12.5px] font-medium text-slate-500 hover:text-slate-300 transition-colors"
+        >
+          also an MCP server →
+        </a>
+      </div>
 
       <a
         href="#security"

--- a/frontend/components/LandingSections.tsx
+++ b/frontend/components/LandingSections.tsx
@@ -8,7 +8,7 @@ import React, { useEffect, useState } from "react";
 const REPO_API_URL = "https://api.github.com/repos/jmxt3/Git-Scape-Web";
 const REPO_URL = "https://github.com/jmxt3/Git-Scape-Web";
 
-const CheckRow: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+export const CheckRow: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div className="flex items-center gap-3">
     <div
       className="flex items-center justify-center shrink-0 rounded-md"
@@ -100,6 +100,13 @@ export const HowItWorks: React.FC = () => (
           </div>
         ))}
       </div>
+      <p className="m-0 text-center text-[13px] text-slate-500">
+        The same pipeline runs behind the{" "}
+        <a href="#developer-tools" className="text-violet-400 hover:text-violet-300 transition-colors font-medium">
+          CLI and the MCP server
+        </a>
+        .
+      </p>
     </div>
   </section>
 );
@@ -272,6 +279,14 @@ const FAQ_ITEMS = [
   {
     q: "What is Code Visualization?",
     a: "Code Visualization renders an interactive, zoomable diagram of your repository's file and directory structure, making it easy to explore and understand the architecture of any codebase at a glance."
+  },
+  {
+    q: "How do I use GitScape from the terminal?",
+    a: "Run npx gitscape <repository_url> — no install or signup needed. The CLI compiles the repo, writes SKILL.md, manifest.json and references into .agents/skills/<owner-repo>/ in your project, and auto-registers the skill in your AGENTS.md and CLAUDE.md. Use --token for private repositories, and npx gitscape remove <name> to uninstall."
+  },
+  {
+    q: "Does GitScape have an MCP server?",
+    a: "Yes. Run npx gitscape init to create a .mcp.json pointing at the GitScape MCP server, or add https://gitscape-143600285956.us-central1.run.app/api/mcp to Claude Code, Cursor or Windsurf. Your agent can then call the install_skill tool to compile, scan and install any repository as a skill on its own."
   },
   {
     q: "Does GitScape AI support private repositories?",

--- a/frontend/components/SkillExport.tsx
+++ b/frontend/components/SkillExport.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import "highlight.js/styles/github-dark.css";
 import { CategoryResult, ScanReport, ScanStatus, SkillManifest, SkillReferences } from "../types";
+import { CodeSnippet } from "./CodeSnippet";
 
 interface SkillExportProps {
   skillMd: string;
@@ -716,6 +717,22 @@ export const SkillExport: React.FC<SkillExportProps> = ({
           </label>
         )}
       </div>
+
+      {repoUrl && !hardBlocked && (
+        <div
+          className="rounded-xl px-4 py-3.5 flex flex-col gap-2"
+          style={{ background: "rgba(245,158,11,0.06)", border: "1px solid rgba(245,158,11,0.25)" }}
+        >
+          <p className="text-xs font-semibold text-amber-300 m-0">
+            Install this skill straight into your project
+          </p>
+          <CodeSnippet compact prompt accent="amber" code={`npx gitscape ${repoUrl}`} />
+          <p className="text-[11px] text-slate-500 m-0">
+            Runs the same compile + ScapeGuard scan, writes the files into
+            <span className="font-mono text-slate-400"> .agents/skills/</span> and registers them in your AGENTS.md.
+          </p>
+        </div>
+      )}
 
       {hardBlocked && (
         <p className="text-xs text-red-400 bg-red-900/20 border border-red-700/40 px-3 py-2 rounded-lg">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,8 +17,8 @@
   <!-- Primary Meta Tags -->
   <title>GitScape AI – Turn GitHub Repos into AI Agent Skills</title>
   <meta name="title" content="GitScape AI – Turn GitHub Repos into AI Agent Skills">
-  <meta name="description" content="Convert GitHub repositories into code digests, interactive diagrams, and structured SKILL.md files. Forge ready-to-load skills for your AI coding agents.">
-  <meta name="keywords" content="github repositories to agent skills, agent skills, openai skills, cloud skills, topic skills, openai agent skills, SKILL.md generator, ai agent skill, repo to llm context, github repository to text, agent knowledge base, git digest, repo ingestion, codebase context, llm code understanding, ai coding agent, repo visualization, github diagram, agentic coding, gitscape, git scape ai">
+  <meta name="description" content="Convert GitHub repositories into code digests, interactive diagrams, and structured SKILL.md files — via web, one-command CLI (npx gitscape), or MCP server. Forge ready-to-load skills for your AI coding agents.">
+  <meta name="keywords" content="github repositories to agent skills, agent skills, openai skills, cloud skills, topic skills, openai agent skills, SKILL.md generator, ai agent skill, repo to llm context, github repository to text, agent knowledge base, git digest, repo ingestion, codebase context, llm code understanding, ai coding agent, repo visualization, github diagram, agentic coding, gitscape, git scape ai, gitscape cli, npx gitscape, mcp server, model context protocol, install agent skill cli">
   <meta name="robots" content="index, follow, max-snippet:160, max-image-preview:large">
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="language" content="English">
@@ -30,7 +30,7 @@
   <meta property="og:site_name" content="GitScape AI">
   <meta property="og:locale" content="en_US">
   <meta property="og:title" content="GitScape AI – Turn GitHub Repos into AI Agent Skills">
-  <meta property="og:description" content="Convert GitHub repositories into code digests, interactive diagrams, and structured SKILL.md files. Forge ready-to-load skills for your AI coding agents.">
+  <meta property="og:description" content="Convert GitHub repositories into code digests, interactive diagrams, and structured SKILL.md files — via web, one-command CLI (npx gitscape), or MCP server. Forge ready-to-load skills for your AI coding agents.">
   <meta property="og:image" content="https://gitscape.ai/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -41,7 +41,7 @@
   <meta name="twitter:url" content="https://gitscape.ai/">
   <meta name="twitter:creator" content="@jmachete">
   <meta name="twitter:title" content="GitScape AI – Turn GitHub Repos into AI Agent Skills">
-  <meta name="twitter:description" content="Convert GitHub repositories into code digests, interactive diagrams, and structured SKILL.md files. Forge ready-to-load skills for your AI coding agents.">
+  <meta name="twitter:description" content="Convert GitHub repositories into code digests, interactive diagrams, and structured SKILL.md files — via web, one-command CLI (npx gitscape), or MCP server. Forge ready-to-load skills for your AI coding agents.">
   <meta name="twitter:image" content="https://gitscape.ai/og-image.png">
   <meta name="twitter:image:alt" content="GitScape AI — convert GitHub repos into AI agent skills">
 
@@ -80,7 +80,9 @@
           "Interactive repository structure diagrams",
           "AI agent SKILL.md export",
           "Supports public and private repositories",
-          "LLM-ready context output"
+          "LLM-ready context output",
+          "One-command CLI installer (npx gitscape)",
+          "MCP server for agent-native skill installation"
         ],
         "author": {
           "@type": "Person",
@@ -142,6 +144,22 @@
             "acceptedAnswer": {
               "@type": "Answer",
               "text": "Code Visualization renders an interactive, zoomable diagram of your repository's file and directory structure, making it easy to explore and understand the architecture of any codebase at a glance."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I use GitScape from the terminal?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Run npx gitscape <repository_url> — no install or signup needed. The CLI compiles the repo, writes SKILL.md, manifest.json and references into .agents/skills/<owner-repo>/ in your project, and auto-registers the skill in your AGENTS.md and CLAUDE.md. Use --token for private repositories, and npx gitscape remove <name> to uninstall."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does GitScape have an MCP server?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Run npx gitscape init to create a .mcp.json pointing at the GitScape MCP server, or add https://gitscape-143600285956.us-central1.run.app/api/mcp to Claude Code, Cursor or Windsurf. Your agent can then call the install_skill tool to compile, scan and install any repository as a skill on its own."
             }
           },
           {


### PR DESCRIPTION
## What changed

The website previously had zero mention of the recently shipped `gitscape` CLI and MCP server. This PR surfaces both across the landing page to drive workflow adoption, following a positioning ladder: **Web = try it now → CLI = adopt it in your repo → MCP = agent-native**.

- **New `DevTools` section** (`#developer-tools`, placed before "How it works") with three tabs matching the site's per-stage color language:
  - **Terminal** (violet): copyable `npx gitscape <repo>` / `remove` commands + what the CLI writes (`.agents/skills/`, AGENTS.md/CLAUDE.md registration, `--token`, `--type framework`)
  - **Your agent** (emerald): `npx gitscape init`, ready-to-paste `.mcp.json` config, and an example `install_skill` prompt for Claude Code / Cursor / Windsurf
  - **Web** (amber): loops back to the generator
- **New `CodeSnippet` component** — reusable copy-to-clipboard code block (full + compact variants), styled to match the existing scan-report panel
- **Post-generation upsell in `SkillExport`** — amber callout with the actual repo URL interpolated into a copyable `npx gitscape <url>` command; hidden when ScapeGuard hard-blocks export
- **Touchpoints**: hero npx pill + "also an MCP server →" link, header nav "CLI & MCP" link, How-it-works footnote, two new FAQ entries, footer "CLI on npm" / "MCP server" links
- **SEO**: FAQ entries mirrored verbatim into the JSON-LD FAQPage schema, plus meta/OG/Twitter descriptions, keywords, and WebApplication featureList updates

## Why

The CLI and MCP server are the actual integration paths for developers; the web app alone is a one-off demo. The README documents both, but the site never mentioned them — this closes that gap at every conversion moment, including the highest-intent one (right after a skill is generated).

## Reviewer notes

- Verified in the browser: section/tab rendering, anchors, copy buttons (exact clipboard text), 375px mobile layout, clean console, and `npm run build` passes. The SkillExport upsell was verified via build + code path only, since it requires a live backend generation to render.
- The MCP URL shown is the `run.app` one that `gitscape init` actually writes. If `api.gitscape.ai` is the preferred public URL, swap it in `DevToolsSection.tsx`, the FAQ copy, and `index.html`.
- Pre-existing (not touched here): `gitscape init --server <local>` writes an `/api/mcp` path the local backend doesn't serve — worth a small CLI follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)