### PR TITLE
fix: use gitscape.ai domain for MCP server URL

### DIFF
--- a/frontend/components/DevToolsSection.tsx
+++ b/frontend/components/DevToolsSection.tsx
@@ -7,7 +7,7 @@ import { CheckRow } from "./LandingSections";
  * Web = try it now, CLI = adopt it in your repo, MCP = agent-native.
  */
 
-const MCP_URL = "https://gitscape-143600285956.us-central1.run.app/api/mcp";
+const MCP_URL = "https://gitscape.ai/api/mcp";
 
 const MCP_JSON = `{
   "mcpServers": {

--- a/frontend/components/LandingSections.tsx
+++ b/frontend/components/LandingSections.tsx
@@ -286,7 +286,7 @@ const FAQ_ITEMS = [
   },
   {
     q: "Does GitScape have an MCP server?",
-    a: "Yes. Run npx gitscape init to create a .mcp.json pointing at the GitScape MCP server, or add https://gitscape-143600285956.us-central1.run.app/api/mcp to Claude Code, Cursor or Windsurf. Your agent can then call the install_skill tool to compile, scan and install any repository as a skill on its own."
+    a: "Yes. Run npx gitscape init to create a .mcp.json pointing at the GitScape MCP server, or add https://gitscape.ai/api/mcp to Claude Code, Cursor or Windsurf. Your agent can then call the install_skill tool to compile, scan and install any repository as a skill on its own."
   },
   {
     q: "Does GitScape AI support private repositories?",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -159,7 +159,7 @@
             "name": "Does GitScape have an MCP server?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Yes. Run npx gitscape init to create a .mcp.json pointing at the GitScape MCP server, or add https://gitscape-143600285956.us-central1.run.app/api/mcp to Claude Code, Cursor or Windsurf. Your agent can then call the install_skill tool to compile, scan and install any repository as a skill on its own."
+              "text": "Yes. Run npx gitscape init to create a .mcp.json pointing at the GitScape MCP server, or add https://gitscape.ai/api/mcp to Claude Code, Cursor or Windsurf. Your agent can then call the install_skill tool to compile, scan and install any repository as a skill on its own."
             }
           },
           {


### PR DESCRIPTION
## What changed

Swaps the Cloud Run URL (`https://gitscape-143600285956.us-central1.run.app/api/mcp`) for the branded `https://gitscape.ai/api/mcp` in all three places the MCP server URL appears on the site:

- `MCP_URL` constant in `DevToolsSection.tsx` (feeds the `.mcp.json` snippet on the "Your agent" tab)
- The MCP FAQ answer in `LandingSections.tsx`
- The matching JSON-LD FAQPage entry in `index.html` (kept verbatim-synced with the FAQ copy)

## Why

Follow-up to the CLI/MCP showcase (#5, already merged). A PR review asked for the public-facing domain instead of the raw Cloud Run URL. This commit landed on the branch just after #5 merged, so it wasn't included and needs its own PR.

## Reviewer notes

- Verified in the browser: the "Your agent" tab's `.mcp.json` block renders `https://gitscape.ai/api/mcp`, the old URL is gone from all three files, and the FAQ copy still matches the JSON-LD verbatim.
- Frontend-only. The CLI's `gitscape init` (in `cli/bin/gitscape.js`) still writes the run.app URL into `.mcp.json` — a separate change if you want it aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)