### PR TITLE
feat(scanner): tree-sitter behavioral analysis (Phase C, GS-EXE-010)

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -34,6 +34,9 @@ registry and deterministic gate. Derived material includes:
 - **OSV.dev batch-lookup + TTL-cache design** in `backend/app/skillforge/scan/osv.py`,
   feeding the supply-chain rules GS-DEP-006 (known vulnerability) and GS-DEP-007
   (malicious package).
+- **Behavioral dangerous-call taxonomy** in `backend/app/skillforge/scan/behavioral.py`
+  (GS-EXE-010) — the exec/eval/subprocess/chain detection classes are derived from
+  SkillSpector's AST analyzer (reimplemented on tree-sitter across Python/JS/TS/Go).
 
 ### Apache License 2.0
 

--- a/backend/app/skillforge/extract/symbols.py
+++ b/backend/app/skillforge/extract/symbols.py
@@ -16,56 +16,10 @@ from pathlib import PurePosixPath
 from typing import Optional
 
 from ..models import ApiIndex, ContentUnit, FileKind, Symbol
-
-# file suffix -> tree-sitter grammar key used by get_parser
-SUFFIX_TO_LANG: dict[str, str] = {
-    ".py": "python",
-    ".ts": "typescript",
-    ".mts": "typescript",
-    ".cts": "typescript",
-    ".tsx": "tsx",
-    ".js": "javascript",
-    ".jsx": "javascript",
-    ".mjs": "javascript",
-    ".cjs": "javascript",
-    ".go": "go",
-}
+from ..tslang import SUFFIX_TO_LANG, get_parser as _get_parser
 
 _MAX_SYMBOLS_PER_FILE = 40
 _MAX_SIG = 200
-
-# Lazily-built parsers, keyed by grammar.
-_PARSERS: dict[str, object] = {}
-
-
-def _get_parser(lang: str):
-    parser = _PARSERS.get(lang)
-    if parser is not None:
-        return parser
-    from tree_sitter import Language, Parser  # local import keeps native dep lazy
-
-    if lang == "python":
-        import tree_sitter_python as ts
-
-        capsule = ts.language()
-    elif lang in ("typescript", "tsx"):
-        import tree_sitter_typescript as ts
-
-        capsule = ts.language_tsx() if lang == "tsx" else ts.language_typescript()
-    elif lang == "javascript":
-        import tree_sitter_javascript as ts
-
-        capsule = ts.language()
-    elif lang == "go":
-        import tree_sitter_go as ts
-
-        capsule = ts.language()
-    else:  # pragma: no cover - guarded by SUFFIX_TO_LANG
-        raise ValueError(f"unsupported grammar: {lang}")
-
-    parser = Parser(Language(capsule))
-    _PARSERS[lang] = parser
-    return parser
 
 
 # ─── helpers ───────────────────────────────────────────────────────────────

--- a/backend/app/skillforge/scan/behavioral.py
+++ b/backend/app/skillforge/scan/behavioral.py
@@ -1,0 +1,191 @@
+"""
+Behavioral analysis of code via tree-sitter (GS-EXE-010).
+
+Regex rules match text; this walks the *parsed* AST of fenced code blocks (and
+any shipped script files) to catch dangerous dynamic execution with far fewer
+false positives — and to spot obfuscation *chains* like `exec(compile(...))` or
+`eval(atob(...))` that a single regex can't reliably see.
+
+Risk gradient — a payload in an executable script file is trusted at run time and
+weighs more than the same construct shown in a documentation code block:
+
+              | fenced code in docs | real script file
+  chain       | HIGH                | CRITICAL
+  exec/eval   | MEDIUM              | HIGH
+  subprocess… | LOW                 | MEDIUM
+
+So a `eval()` shown as a README example never hard-blocks an export, while the
+same call inside a shipped `.py` can. tree-sitter is error-tolerant, so partial
+snippets still parse; any parser error is swallowed (never breaks the scan).
+
+The dangerous-call taxonomy is derived from NVIDIA SkillSpector's behavioral AST
+analyzer (https://github.com/NVIDIA/SkillSpector), Apache-2.0. See
+THIRD_PARTY_NOTICES.md.
+
+Author: GitScape.ai
+"""
+from __future__ import annotations
+
+import re
+
+from ..models import Confidence, ScanFinding, Severity
+from ..tslang import SUFFIX_TO_LANG, get_parser
+from .context import ScanContext
+from .registry import Rule
+
+# fenced-block language label -> grammar key
+_FENCE_LANG = {
+    "python": "python", "py": "python", "python3": "python",
+    "javascript": "javascript", "js": "javascript", "node": "javascript",
+    "typescript": "typescript", "ts": "typescript",
+    "tsx": "tsx", "jsx": "javascript",
+    "go": "go", "golang": "go",
+}
+_FENCE = re.compile(r"```([A-Za-z0-9_+#-]*)[ \t]*\r?\n(.*?)```", re.S)
+
+# grammar -> (call node type, callee field name)
+_CALL = {
+    "python": ("call", "function"),
+    "javascript": ("call_expression", "function"),
+    "typescript": ("call_expression", "function"),
+    "tsx": ("call_expression", "function"),
+    "go": ("call_expression", "function"),
+}
+
+# exec/eval tier — HIGH in scripts, MEDIUM in docs (CRITICAL/HIGH when chained)
+_EXEC: dict[str, set[str]] = {
+    "python": {"exec", "eval", "os.system"},
+    "javascript": {"eval", "child_process.exec", "child_process.execSync"},
+    "typescript": {"eval", "child_process.exec", "child_process.execSync"},
+    "tsx": {"eval", "child_process.exec", "child_process.execSync"},
+    "go": set(),
+}
+# lower tier — MEDIUM in scripts, LOW in docs
+_LOWER: dict[str, set[str]] = {
+    "python": {"compile", "__import__", "subprocess.run", "subprocess.call",
+               "subprocess.Popen", "subprocess.check_output", "subprocess.check_call",
+               "pickle.loads", "marshal.loads"},
+    "javascript": set(),
+    "typescript": set(),
+    "tsx": set(),
+    "go": {"exec.Command", "exec.CommandContext"},
+}
+# decode/danger callees that, nested inside an exec/eval argument, mark a chain
+_DECODE = {"base64.b64decode", "bytes.fromhex", "codecs.decode", "atob",
+           "exec", "eval", "compile", "__import__", "marshal.loads", "pickle.loads"}
+
+_MAX_FINDINGS = 25  # don't flood on a pathological input
+
+
+def extract_code_blocks(markdown: str) -> list[tuple[str, str, int]]:
+    """Yield (grammar_key, code, line_offset) for supported fenced blocks."""
+    out: list[tuple[str, str, int]] = []
+    for m in _FENCE.finditer(markdown):
+        lang = _FENCE_LANG.get((m.group(1) or "").lower())
+        if not lang:
+            continue
+        out.append((lang, m.group(2), markdown.count("\n", 0, m.start(2))))
+    return out
+
+
+def _walk(node):
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        yield n
+        stack.extend(n.children)
+
+
+def _txt(node, src: bytes) -> str:
+    return src[node.start_byte:node.end_byte].decode("utf-8", "replace")
+
+
+def _snip(node, src: bytes) -> str:
+    return " ".join(_txt(node, src).split())[:120]
+
+
+def _detect(lang: str, code: str, is_script: bool) -> list[tuple[Severity, Confidence, str, int, str]]:
+    """Return (severity, confidence, snippet, rel_line, label) for dangerous calls."""
+    parser = get_parser(lang)
+    src = code.encode("utf-8")
+    tree = parser.parse(src)
+    call_type, callee_field = _CALL[lang]
+    exec_set, lower_set = _EXEC[lang], _LOWER[lang]
+    hits: list[tuple[Severity, Confidence, str, int, str]] = []
+
+    for node in _walk(tree.root_node):
+        # `new Function(...)` (JS/TS) — dynamic code construction
+        if lang in ("javascript", "typescript", "tsx") and node.type == "new_expression":
+            ctor = node.child_by_field_name("constructor")
+            if ctor is not None and _txt(ctor, src) == "Function":
+                sev = Severity.HIGH if is_script else Severity.MEDIUM
+                conf = Confidence.HIGH if is_script else Confidence.MEDIUM
+                hits.append((sev, conf, _snip(node, src), node.start_point[0], "new Function"))
+            continue
+
+        if node.type != call_type:
+            continue
+        callee = node.child_by_field_name(callee_field)
+        if callee is None:
+            continue
+        name = _txt(callee, src)
+        if name in exec_set:
+            tier = "exec"
+        elif name in lower_set:
+            tier = "lower"
+        else:
+            continue
+
+        chained = False
+        if tier == "exec":
+            args = node.child_by_field_name("arguments")
+            if args is not None:
+                for sub in _walk(args):
+                    if sub is node or sub.type not in ("call", "call_expression"):
+                        continue
+                    subcallee = sub.child_by_field_name("function")
+                    if subcallee is not None and _txt(subcallee, src) in _DECODE:
+                        chained = True
+                        break
+
+        if chained:
+            sev = Severity.CRITICAL if is_script else Severity.HIGH
+            conf = Confidence.HIGH if is_script else Confidence.MEDIUM
+        elif tier == "exec":
+            sev = Severity.HIGH if is_script else Severity.MEDIUM
+            conf = Confidence.HIGH if is_script else Confidence.MEDIUM
+        else:
+            sev = Severity.MEDIUM if is_script else Severity.LOW
+            conf = Confidence.MEDIUM if is_script else Confidence.LOW
+        hits.append((sev, conf, _snip(node, src), node.start_point[0], name))
+    return hits
+
+
+def check_behavioral(ctx: ScanContext, rule: Rule) -> list[ScanFinding]:
+    """GS-EXE-010: AST-based dangerous-call detection over code blocks + scripts."""
+    findings: list[ScanFinding] = []
+    for label, text in ctx.all_surfaces():
+        suffix = ("." + label.rsplit(".", 1)[-1].lower()) if "." in label else ""
+        script_lang = SUFFIX_TO_LANG.get(suffix)
+        if script_lang is not None:
+            blocks = [(script_lang, text, 0)]
+            is_script = True
+        else:
+            blocks = extract_code_blocks(text)
+            is_script = False
+        for lang, code, offset in blocks:
+            try:
+                hits = _detect(lang, code, is_script)
+            except Exception:
+                continue  # a parser error must never break the scan
+            for sev, conf, snip, rel_line, name in hits:
+                chain = " (obfuscation chain)" if sev in (Severity.CRITICAL,) or (
+                    not is_script and sev == Severity.HIGH) else ""
+                findings.append(rule.finding(
+                    file=label, line=offset + rel_line + 1, snippet=snip,
+                    severity=sev, confidence=conf,
+                    message=f"Dangerous dynamic execution via `{name}`{chain} (AST-detected).",
+                ))
+                if len(findings) >= _MAX_FINDINGS:
+                    return findings
+    return findings

--- a/backend/app/skillforge/scan/rules/execution.py
+++ b/backend/app/skillforge/scan/rules/execution.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import re
 
 from ...models import Confidence, Severity
+from ..behavioral import check_behavioral
 from ..registry import Rule
 from ..taxonomy import Category
 
@@ -109,5 +110,15 @@ RULES: list[Rule] = [
             re.I),
         message="Offensive tooling / webshell signature (credential dumping, exploitation, or PHP webshell).",
         remediation="Remove the offensive-tooling reference; it has no place in a legitimate skill.",
+    ),
+    Rule(
+        # AST-based (tree-sitter) dangerous-call detection over fenced code blocks
+        # and shipped scripts. Per-finding severity is set by the check (risk
+        # gradient: CRITICAL only for chains in real script files).
+        id="GS-EXE-010", name="execution.behavioral_dangerous_call", category=C,
+        severity=Severity.HIGH, confidence=Confidence.HIGH,
+        check=check_behavioral,
+        message="Dynamic code execution / dangerous call detected by AST analysis.",
+        remediation="Avoid exec/eval and dynamic code execution in a shipped skill.",
     ),
 ]

--- a/backend/app/skillforge/tslang.py
+++ b/backend/app/skillforge/tslang.py
@@ -1,0 +1,59 @@
+"""
+Shared tree-sitter parser loader.
+
+One lazily-built parser per grammar, reused by both the symbol extractor
+(`extract/symbols.py`) and the behavioral scanner (`scan/behavioral.py`).
+Grammars ship as individual `tree-sitter-<lang>` wheels (Python, TypeScript/TSX,
+JavaScript, Go); the native dependency stays lazy until a parser is requested.
+
+Author: GitScape.ai
+"""
+from __future__ import annotations
+
+# file suffix -> grammar key
+SUFFIX_TO_LANG: dict[str, str] = {
+    ".py": "python",
+    ".ts": "typescript",
+    ".mts": "typescript",
+    ".cts": "typescript",
+    ".tsx": "tsx",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".go": "go",
+}
+
+# Lazily-built parsers, keyed by grammar.
+_PARSERS: dict[str, object] = {}
+
+
+def get_parser(lang: str):
+    """Return a cached tree-sitter Parser for a grammar key (raises on unknown)."""
+    parser = _PARSERS.get(lang)
+    if parser is not None:
+        return parser
+    from tree_sitter import Language, Parser  # local import keeps native dep lazy
+
+    if lang == "python":
+        import tree_sitter_python as ts
+
+        capsule = ts.language()
+    elif lang in ("typescript", "tsx"):
+        import tree_sitter_typescript as ts
+
+        capsule = ts.language_tsx() if lang == "tsx" else ts.language_typescript()
+    elif lang == "javascript":
+        import tree_sitter_javascript as ts
+
+        capsule = ts.language()
+    elif lang == "go":
+        import tree_sitter_go as ts
+
+        capsule = ts.language()
+    else:
+        raise ValueError(f"unsupported grammar: {lang}")
+
+    parser = Parser(Language(capsule))
+    _PARSERS[lang] = parser
+    return parser

--- a/backend/tests/test_scan_behavioral.py
+++ b/backend/tests/test_scan_behavioral.py
@@ -1,0 +1,92 @@
+"""
+Behavioral (tree-sitter AST) analysis tests — GS-EXE-010.
+
+Verifies the risk gradient (docs vs scripts), obfuscation-chain escalation, and
+— critically — that a dangerous call shown in a *documentation* code block never
+becomes an unbypassable hard-block, while the same call in a shipped script can.
+"""
+from app.skillforge.models import ScanStatus, Severity
+from app.skillforge.package import has_unbypassable_finding
+from app.skillforge.scan import scan_skill
+from app.skillforge.scan.behavioral import extract_code_blocks
+
+
+def _ids(report):
+    return {f.id for f in report.findings}
+
+
+def _exe010(report):
+    return [f for f in report.findings if f.id == "GS-EXE-010"]
+
+
+# ── fenced-block extraction ──────────────────────────────────────────────────
+
+def test_extract_code_blocks_maps_language_and_offset():
+    md = "intro\n\n```python\nx = 1\n```\n"
+    blocks = extract_code_blocks(md)
+    assert len(blocks) == 1
+    lang, code, offset = blocks[0]
+    assert lang == "python" and "x = 1" in code and offset == 3
+
+
+def test_unlabeled_and_shell_blocks_are_ignored():
+    md = "```\nplain\n```\n```bash\ncurl x\n```\n"
+    assert extract_code_blocks(md) == []
+
+
+# ── docs tier (never a hard block) ───────────────────────────────────────────
+
+def test_doc_eval_is_warn_not_fail():
+    md = "# Skill\n\n```python\nresult = eval(user_input)\n```\n"
+    report = scan_skill(md, {})
+    hits = _exe010(report)
+    assert hits and hits[0].severity == Severity.MEDIUM
+    assert report.status == ScanStatus.WARN
+
+
+def test_doc_chain_is_fail_but_bypassable():
+    md = "# Skill\n\n```python\nexec(compile(payload, '<s>', 'exec'))\n```\n"
+    report = scan_skill(md, {})
+    hits = _exe010(report)
+    assert hits and hits[0].severity == Severity.HIGH  # doc chain caps at HIGH
+    assert report.status == ScanStatus.FAIL
+    assert not has_unbypassable_finding(report)  # a doc example must not hard-block
+
+
+def test_js_new_function_detected():
+    md = "# Skill\n\n```js\nconst f = new Function('return ' + x);\n```\n"
+    report = scan_skill(md, {})
+    assert "GS-EXE-010" in _ids(report)
+
+
+# ── script tier (can hard block) ─────────────────────────────────────────────
+
+def test_script_chain_is_critical_and_unbypassable():
+    scripts = {"helper.py": "import base64\nexec(compile(base64.b64decode(x), '<s>', 'exec'))\n"}
+    report = scan_skill("# Skill", {}, scripts=scripts)
+    hits = _exe010(report)
+    assert hits and hits[0].severity == Severity.CRITICAL
+    assert report.status == ScanStatus.FAIL
+    assert has_unbypassable_finding(report)  # RCE chain in a real script never ships
+
+
+# ── false-positive guards ────────────────────────────────────────────────────
+
+def test_prose_mentioning_eval_is_not_flagged():
+    # "eval" in prose, no code block → nothing to parse → no behavioral finding.
+    report = scan_skill("# Skill\n\nAvoid using eval() on untrusted input.\n", {})
+    assert "GS-EXE-010" not in _ids(report)
+
+
+def test_benign_fenced_code_is_clean():
+    md = "# Skill\n\n```python\nrows = read_csv(path)\nwrite_csv(out, rows)\n```\n"
+    report = scan_skill(md, {})
+    assert "GS-EXE-010" not in _ids(report)
+    assert report.status == ScanStatus.PASS
+
+
+def test_regex_dot_exec_is_not_flagged():
+    # `.exec` on a regex is common and benign; only whitelisted callees fire.
+    md = "# Skill\n\n```js\nconst m = /foo/.exec(str);\n```\n"
+    report = scan_skill(md, {})
+    assert "GS-EXE-010" not in _ids(report)

--- a/frontend/components/ScanBadge.tsx
+++ b/frontend/components/ScanBadge.tsx
@@ -140,6 +140,7 @@ const SCAPEGUARD_RULE_LABELS: Record<string, string> = {
   "GS-EXE-007": "Chmod & Run — Downloads a file and immediately makes it executable or runs it",
   "GS-EXE-008": "Cryptominer — Mining-pool protocol or known miner binary reference",
   "GS-EXE-009": "Hacktool / Webshell — Credential dumping, exploitation, or PHP webshell signature",
+  "GS-EXE-010": "Dangerous Call (AST) — Dynamic code execution detected by tree-sitter analysis",
 
   // Data Exfiltration (GS-EXF)
   "GS-EXF-001": "Send Secrets — Instruction to send secrets/credentials outward",


### PR DESCRIPTION
## What (Phase C)

Adds **AST-based** dangerous-call detection over fenced code blocks and shipped scripts, catching dynamic execution and obfuscation chains that regex misses.

> Re-opened cleanly off `main`: this work was originally pushed to the Phase B branch *after* PR #9 had already merged (at Phase B), so it never landed. This PR carries the same commit onto a fresh branch.

## Changes
- **`tslang.py`** (new) — shared tree-sitter parser loader, refactored out of `extract/symbols.py` (which now imports it). Grammars for Python/JS/TS/Go already shipped.
- **`scan/behavioral.py`** (new) — `extract_code_blocks()` + per-language dangerous-call walk (`exec`/`eval`/`os.system`/`new Function`/`subprocess`/`exec.Command`) with obfuscation-chain detection (`exec(compile(...))`, `eval(atob(...))`).
- **`GS-EXE-010`** risk gradient — a dangerous call in a **doc** code block caps at HIGH (bypassable), so README examples never hard-block an export; the same call in a **shipped script** can be CRITICAL (unbypassable). Parser errors swallowed; findings capped at 25.
- **`test_scan_behavioral.py`** — docs-vs-script gradient, chain escalation, and FP guards (prose "eval", regex `.exec`, benign fenced code stay clean).
- ScanBadge tooltip + THIRD_PARTY_NOTICES attribution.

## Verification
- `pytest backend/tests/` → **173 passed, 1 xfailed**
- `npm run build` clean

Behavioral taxonomy derived from NVIDIA SkillSpector's AST analyzer (Apache-2.0), reimplemented on tree-sitter. Credited in THIRD_PARTY_NOTICES.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)