### PR TITLE
docs: document the scan command across CLI README, project README + landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,22 +272,30 @@ cd cli && npm link
     ```bash
     npx gitscape https://github.com/owner/repo
     ```
+    If the ScapeGuard scan **fails** (grade `F`), the CLI blocks the install and writes nothing — re-run with `--accept-risk` to override.
 
-3.  **CLI Command Options**
+3.  **Scan a Repository (Without Installing)**
+    Runs ScapeGuard against a repo and prints the security verdict (grade, risk score, findings) **without building or installing a skill** — nothing is written. Exits non-zero on a failing scan, so it doubles as a CI gate:
+    ```bash
+    npx gitscape scan https://github.com/owner/repo
+    ```
+
+4.  **CLI Command Options**
 
 | Option | Description |
 | :--- | :--- |
 | `--token <pat>` | GitHub Personal Access Token (for private repositories) |
+| `--accept-risk` | Install even if the security scan fails (grade `F`). Off by default |
 | `--type <type>` | Skill type: `code` or `framework` (default: `code`) |
 | `--server <url>` | Override compiler API (default: `https://gitscape-143600285956.us-central1.run.app`) |
 
-4.  **Updating a Skill**
+5.  **Updating a Skill**
     Just re-run the install command. The CLI automatically wipes the target directory to avoid stale files while keeping your `AGENTS.md` registrations intact:
     ```bash
     npx gitscape https://github.com/owner/repo
     ```
 
-5.  **Removing a Skill**
+6.  **Removing a Skill**
     Deletes the directory and cleans up `AGENTS.md` and `CLAUDE.md`:
     ```bash
     npx gitscape remove <skill_name>

--- a/cli/README.md
+++ b/cli/README.md
@@ -75,10 +75,12 @@ Clones the repository, analyzes its structure, runs the ScapeGuard security scan
 
 Each compile prints the skill's **ScapeGuard security grade** (`A`–`F`); the full report ships alongside the skill as `scan-report.json` and `scan-report.sarif`.
 
+> **Security gate:** if the scan **fails** (grade `F`), the CLI does **not** write any files. Review the findings with `npx gitscape scan <url>`, or re-run with `--accept-risk` to install anyway.
+
 **Example:**
 ```bash
 npx gitscape https://github.com/google/adk-python
-# ✓ Skill compiled successfully (Scan Grade: A)
+# ✓ Skill compiled successfully (Scan Grade: A, PASS)
 #   write .agents/skills/google-adk-python/SKILL.md
 #   ...
 #   ✓ Skill google-adk-python installed to .agents/skills/google-adk-python
@@ -86,10 +88,42 @@ npx gitscape https://github.com/google/adk-python
 
 **Options:**
 * `--token <pat>`: Optional GitHub Personal Access Token (PAT) for compiling private repositories.
+* `--accept-risk`: Install the skill even if the security scan fails (grade `F`). Off by default.
 
 ---
 
-### 2. Initialize Workspace MCP
+### 2. Scan a Repo (Without Installing)
+```bash
+npx gitscape scan <repository_url>
+```
+Runs ScapeGuard against a repository and prints the security verdict **without building or installing a skill** — nothing is written to disk. Use it to vet a repo before installing, or as a **CI gate** (the command exits non-zero when the scan fails).
+
+**Example:**
+```bash
+npx gitscape scan https://github.com/google/adk-python
+#   ScapeGuard: grade A · PASS · risk 0 · 0 findings
+#
+# ✓ Safe to install (grade A). Nothing was written.
+```
+
+A failing scan prints each finding and exits with code `1`:
+```bash
+npx gitscape scan https://github.com/acme/suspicious-repo
+#   ScapeGuard: grade F · FAIL · risk 100 · 1 finding
+#     [CRITICAL] GS-INJ-001 — SKILL.md:3
+#            Prompt-injection: attempt to override prior instructions.
+#
+# ✗ FAIL (grade F): this repo's skill would not pass the security gate.
+```
+
+**Options:**
+* `--token <pat>`: Optional GitHub Personal Access Token (PAT) for scanning private repositories.
+
+> **Tip:** Run `npx gitscape` with **no arguments** in a terminal for an interactive menu that lets you choose between compiling and scanning.
+
+---
+
+### 3. Initialize Workspace MCP
 ```bash
 npx gitscape init
 ```
@@ -97,7 +131,7 @@ Creates a local `.mcp.json` file inside your current working directory to regist
 
 ---
 
-### 3. Remove/Uninstall a Skill
+### 4. Remove/Uninstall a Skill
 ```bash
 npx gitscape remove <skill_name>
 # OR
@@ -107,7 +141,7 @@ Deletes the skill folder under `.agents/skills/<name>/` and cleanly removes all 
 
 ---
 
-### 4. Update an Already-Installed Skill
+### 5. Update an Already-Installed Skill
 ```bash
 npx gitscape <repository_url>
 ```

--- a/frontend/components/DevToolsSection.tsx
+++ b/frontend/components/DevToolsSection.tsx
@@ -269,11 +269,12 @@ export const DevTools: React.FC<DevToolsProps> = ({ onSelectTab }) => {
             <div className="flex flex-col gap-3 mt-1">
               <CheckRow>Zero install, runs via <code className="font-mono text-[0.85em] text-slate-200">npx gitscape</code></CheckRow>
               <CheckRow>Auto-registers skills in your rules registry files</CheckRow>
+              <CheckRow>Scan-only mode — <code className="font-mono text-[0.85em] text-slate-200">gitscape scan</code> grades a repo without installing</CheckRow>
               <CheckRow>Supports private repositories using your custom PAT token</CheckRow>
-              <CheckRow>Stateless and runs entirely client-side</CheckRow>
             </div>
             <div className="mt-3 flex flex-col gap-2">
               <CodeSnippet title="install a skill" accent="violet" prompt code="npx gitscape https://github.com/owner/repo" />
+              <CodeSnippet title="scan a repo — no install" accent="violet" prompt code="npx gitscape scan https://github.com/owner/repo" />
             </div>
             <div className="flex justify-start mt-1 pl-1">
               <button


### PR DESCRIPTION
## What

Documents the `scan` feature (shipped in #12) across all three surfaces.

## Changes
**`cli/README.md`**
- New command section **"Scan a Repo (Without Installing)"** — `npx gitscape scan <url>` prints the verdict, writes nothing, exits non-zero on FAIL (CI-gateable), with pass/fail output examples.
- Compile section: the **security gate** (FAIL blocks writes) + the new **`--accept-risk`** option.
- Notes the no-args **interactive menu**.

**`README.md` (project)**
- New "Scan a Repository (Without Installing)" step in the CLI usage flow.
- `--accept-risk` option row + install-gate note on the compile step.

**`frontend/components/DevToolsSection.tsx` (landing)**
- A `npx gitscape scan …` code snippet in the CLI card + a scan-only bullet.

## Verification
- `npm run build` clean; landing verified in preview (scan snippet + bullet render, no console errors).
- CLI README examples match the actual CLI output (verified end-to-end in #12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)