### PR TITLE
Redesign public registry and per-repo security report pages (Aurora)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1112,22 +1112,9 @@ const App: React.FC = () => {
               />
             );
           }
-          // /registry — index page
+          // /registry — index page (full-bleed: the view brings its own hero band)
           if (currentPath === '/registry') {
-            return (
-              <div className="max-w-[1100px] mx-auto px-4 sm:px-6 py-8 sm:py-12 flex-grow w-full mt-6">
-                <div
-                  className="rounded-2xl p-5 sm:p-7 flex flex-col gap-6"
-                  style={{
-                    background: "rgba(15,23,42,0.75)",
-                    border: "1px solid rgba(6,182,212,0.35)",
-                    boxShadow: "0 12px 48px -12px rgba(0,0,0,0.6), 0 0 0 1px rgba(139,92,246,0.08)",
-                  }}
-                >
-                  <RegistryView onNavigate={navigateTo} />
-                </div>
-              </div>
-            );
+            return <RegistryView onNavigate={navigateTo} />;
           }
           // Home page
           return (

--- a/frontend/components/RegistryView.tsx
+++ b/frontend/components/RegistryView.tsx
@@ -1,5 +1,18 @@
-import React, { useState, useEffect } from "react";
-import { ScanFinding, ScanReport, SkillManifest } from "../types";
+// Author: Joao Machete
+// Description: Public Agent Skill Registry index page — Aurora design. A full-page
+// certification-ledger layout: hero with registry pulse stats, grade filters,
+// grid/list toggle, and seal cards that navigate to per-repo security reports.
+import React, { useState, useEffect, useMemo } from "react";
+import {
+  gradeInfo,
+  statusColor,
+  fmtK,
+  glassStyle,
+  Eyebrow,
+  RepoMark,
+  GradeSeal,
+  GradeChip,
+} from "./registryTheme";
 
 interface RegistrySkill {
   repo_url: string;
@@ -13,339 +26,395 @@ interface RegistrySkill {
   status: string;
   risk_score: number;
   findings_count: number;
-  freshness: string;
+  freshness?: string;
+  scanned_at?: string;
+  stars?: number;
 }
 
-interface DetailPayload {
-  repo_url: string;
-  name: string;
-  owner: string;
-  repo: string;
-  description: string;
-  primary_languages: string[];
-  files_analyzed: number;
-  grade: string;
-  status: string;
-  risk_score: number;
-  findings: ScanFinding[];
-  categories: any[];
-  skill_md: string;
-  manifest: SkillManifest;
-}
+type GradeFilter = "ALL" | "A" | "B" | "C" | "F";
+type SortKey = "risk" | "stars" | "name" | "scanned";
+type Layout = "grid" | "list";
+
+const RISK_BAR_MAX = 60; // visual full-scale for the risk micro-bar
+
+const getApiUrl = (routePath: string) => {
+  const base = (import.meta as any).env?.VITE_API_URL || "";
+  return `${base}/api${routePath}`;
+};
+
+const parseGithubUrl = (raw: string): { owner: string; repo: string } | null => {
+  const m = raw.trim().match(/github\.com\/([^/\s]+)\/([^/\s#?]+)/i);
+  if (!m) return null;
+  return { owner: m[1], repo: m[2].replace(/\.git$/, "") };
+};
+
+const RiskBar: React.FC<{ risk: number; grade: string }> = ({ risk, grade }) => (
+  <span
+    className="inline-flex items-center gap-2 font-mono text-[10.5px] text-slate-400 tabular-nums"
+    title="Weighted risk score"
+  >
+    <span className="inline-block w-[52px] h-1 rounded-sm overflow-hidden" style={{ background: "rgba(30,41,59,0.9)" }}>
+      <i
+        className="block h-full rounded-sm"
+        style={{ width: `${Math.min(100, (risk / RISK_BAR_MAX) * 100)}%`, background: gradeInfo(grade).hex }}
+      />
+    </span>
+    risk {risk}
+  </span>
+);
 
 export const RegistryView: React.FC<{ onNavigate: (path: string) => void }> = ({ onNavigate }) => {
-  const [query, setQuery] = useState<string>("");
   const [skills, setSkills] = useState<RegistrySkill[]>([]);
-  const [loadingList, setLoadingList] = useState<boolean>(true);
-  const [loadingDetail, setLoadingDetail] = useState<boolean>(false);
-  const [selectedSkillUrl, setSelectedSkillUrl] = useState<string | null>(null);
-  const [detail, setDetail] = useState<DetailPayload | null>(null);
-  const [activeTab, setActiveTab] = useState<"findings" | "skill_md" | "manifest">("findings");
-  const [detailError, setDetailError] = useState<string | null>(null);
-
-  // Helper to build API URL
-  const getApiUrl = (routePath: string) => {
-    const base = import.meta.env.VITE_API_URL || "";
-    return `${base}/api${routePath}`;
-  };
-
-  const fetchList = async (searchVal: string) => {
-    setLoadingList(true);
-    try {
-      const url = getApiUrl(`/registry/search${searchVal ? `?query=${encodeURIComponent(searchVal)}` : ""}`);
-      const resp = await fetch(url);
-      if (resp.ok) {
-        const data = await resp.json();
-        setSkills(data);
-      }
-    } catch (e) {
-      console.error("Failed to fetch registry list", e);
-    } finally {
-      setLoadingList(false);
-    }
-  };
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+  const [grade, setGrade] = useState<GradeFilter>("ALL");
+  const [sort, setSort] = useState<SortKey>("risk");
+  const [layout, setLayout] = useState<Layout>("grid");
 
   useEffect(() => {
-    fetchList("");
+    fetch(getApiUrl("/registry/search"))
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => setSkills(Array.isArray(data) ? data : []))
+      .catch((e) => console.error("Failed to fetch registry list", e))
+      .finally(() => setLoading(false));
   }, []);
 
-  const handleSearchSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    fetchList(query);
-  };
+  const githubTarget = parseGithubUrl(query);
 
-  const handleSelectSkill = async (repoUrl: string) => {
-    setSelectedSkillUrl(repoUrl);
-    setLoadingDetail(true);
-    setDetailError(null);
-    setDetail(null);
-    try {
-      const url = getApiUrl(`/registry/detail?repo_url=${encodeURIComponent(repoUrl)}`);
-      const resp = await fetch(url);
-      if (!resp.ok) {
-        throw new Error(`Failed to load details (HTTP ${resp.status})`);
-      }
-      const data = await resp.json();
-      setDetail(data);
-      setActiveTab("findings");
-    } catch (e: any) {
-      setDetailError(e.message || "An error occurred during dynamic compilation.");
-    } finally {
-      setLoadingDetail(false);
-    }
-  };
+  const goToReport = (owner: string, repo: string) => onNavigate(`/registry/${owner}/${repo}`);
 
-  // Compile on the fly for custom searches
-  const handleCompileOnTheFly = () => {
-    if (!query.startsWith("http://") && !query.startsWith("https://")) {
-      alert("Please enter a valid GitHub repository URL in the search input first.");
-      return;
-    }
-    handleSelectSkill(query);
-  };
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { ALL: skills.length, A: 0, B: 0, C: 0, F: 0 };
+    skills.forEach((s) => {
+      if (c[s.grade] !== undefined) c[s.grade]++;
+    });
+    return c;
+  }, [skills]);
 
-  const getGradeBg = (grade: string) => {
-    if (grade === "A") return "bg-emerald-500/10 border-emerald-500/35 text-emerald-400";
-    if (grade === "B") return "bg-lime-500/10 border-lime-500/35 text-lime-400";
-    if (grade === "C") return "bg-amber-500/10 border-amber-500/35 text-amber-400";
-    return "bg-rose-500/10 border-rose-500/35 text-rose-400";
+  const pulse = useMemo(() => {
+    const passN = skills.filter((s) => s.status === "PASS").length;
+    const risks = skills.map((s) => s.risk_score).sort((a, b) => a - b);
+    const median = risks.length ? risks[Math.floor(risks.length / 2)] : 0;
+    const findings = skills.reduce((n, s) => n + (s.findings_count || 0), 0);
+    const langs = new Set(skills.flatMap((s) => s.primary_languages || [])).size;
+    return { passN, median, findings, langs };
+  }, [skills]);
+
+  const list = useMemo(() => {
+    const q = query.toLowerCase();
+    const filtered = skills.filter((s) => {
+      if (grade !== "ALL" && s.grade !== grade) return false;
+      if (!q) return true;
+      return (
+        `${s.owner}/${s.repo}`.toLowerCase().includes(q) ||
+        (s.description || "").toLowerCase().includes(q) ||
+        (s.primary_languages || []).join(" ").toLowerCase().includes(q)
+      );
+    });
+    const cmp: Record<SortKey, (a: RegistrySkill, b: RegistrySkill) => number> = {
+      risk: (a, b) => a.risk_score - b.risk_score || `${a.owner}/${a.repo}`.localeCompare(`${b.owner}/${b.repo}`),
+      stars: (a, b) => (b.stars || 0) - (a.stars || 0),
+      name: (a, b) => `${a.owner}/${a.repo}`.localeCompare(`${b.owner}/${b.repo}`),
+      scanned: (a, b) => (b.scanned_at || "").localeCompare(a.scanned_at || ""),
+    };
+    return [...filtered].sort(cmp[sort]);
+  }, [skills, query, grade, sort]);
+
+  const cardMeta = (s: RegistrySkill) => {
+    const bits: string[] = [];
+    if (s.stars) bits.push(`★ ${fmtK(s.stars)}`);
+    else bits.push(`${(s.files_analyzed || 0).toLocaleString()} files`);
+    if (s.scanned_at) bits.push(`scanned ${s.scanned_at.slice(5, 10)}`);
+    else if (s.freshness) bits.push(s.freshness);
+    return bits.join(" · ");
   };
 
   return (
-    <div className="w-full flex flex-col gap-6 text-slate-200">
-      {/* Search Header */}
-      <div className="flex flex-col md:flex-row gap-3 items-center justify-between">
-        <div>
-          <h2 className="text-xl font-bold tracking-tight text-cyan-400">Public Agent Skill Registry</h2>
-          <p className="text-xs text-slate-400">Search indexed skills, or type any GitHub URL to compile and scan on the fly.</p>
-        </div>
-        <form onSubmit={handleSearchSubmit} className="flex gap-2 w-full md:w-auto min-w-[320px]">
-          <input
-            type="text"
-            placeholder="Search or GitHub Repo URL..."
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="flex-grow px-3.5 py-2 text-xs bg-slate-950/80 border border-slate-800 rounded-lg focus:outline-none focus:border-cyan-500 transition-colors"
-          />
-          <button
-            type="submit"
-            className="px-4 py-2 bg-slate-900 border border-slate-700 hover:border-slate-500 text-xs font-bold rounded-lg transition-colors"
-          >
-            Search
-          </button>
-          {query.includes("github.com/") && (
-            <button
-              type="button"
-              onClick={handleCompileOnTheFly}
-              className="px-4 py-2 bg-cyan-950/80 border border-cyan-800 hover:border-cyan-600 text-xs font-bold text-cyan-400 rounded-lg transition-colors"
-            >
-              Compile &amp; Scan
-            </button>
-          )}
-        </form>
-      </div>
+    <div className="min-h-screen" style={{ background: "#0b1120" }}>
+      {/* ── Hero band ─────────────────────────────────────────────── */}
+      <div
+        className="relative overflow-hidden"
+        style={{
+          background: "linear-gradient(135deg, rgba(124,58,237,0.08) 0%, rgba(6,182,212,0.05) 100%)",
+          borderBottom: "1px solid rgba(71,85,105,0.2)",
+        }}
+      >
+        <div style={{ position: "absolute", top: -80, right: -80, width: 400, height: 400, borderRadius: "50%", background: "radial-gradient(circle, rgba(124,58,237,0.12), transparent 70%)", pointerEvents: "none" }} />
+        <div style={{ position: "absolute", bottom: -60, left: 80, width: 300, height: 300, borderRadius: "50%", background: "radial-gradient(circle, rgba(6,182,212,0.08), transparent 70%)", pointerEvents: "none" }} />
 
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 min-h-[480px]">
-        {/* Left Side: Skills Catalog */}
-        <div className="lg:col-span-5 flex flex-col gap-3.5">
-          <span className="text-[11px] font-bold tracking-wider text-slate-500 uppercase">Available Skills</span>
-          
-          {loadingList ? (
-            <div className="flex items-center justify-center py-20 bg-slate-950/20 border border-slate-900 rounded-xl">
-              <span className="text-xs text-slate-500 animate-pulse">Loading catalog...</span>
-            </div>
-          ) : skills.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-20 bg-slate-950/20 border border-slate-900 rounded-xl text-center px-4">
-              <span className="text-xs text-slate-500 mb-2">No pre-indexed skills found for "{query}"</span>
-              {query.includes("github.com/") && (
+        <div className="max-w-[1180px] mx-auto px-4 sm:px-7 pt-11 pb-2 relative">
+          <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_auto] gap-9 items-end">
+            <div>
+              <Eyebrow>ScapeGuard · security-audited skills</Eyebrow>
+              <h1 className="text-3xl sm:text-[34px] font-extrabold text-slate-100 mt-2.5 mb-2.5" style={{ letterSpacing: "-1px", lineHeight: 1.12 }}>
+                Public Agent Skill Registry
+              </h1>
+              <p className="text-[14.5px] text-slate-400 max-w-[56ch] mb-6">
+                Every skill audited, every grade earned. Search indexed skills, or type any GitHub URL to compile
+                and scan it on the fly with ScapeGuard's five gate categories.
+              </p>
+              <form
+                className="flex gap-2.5 max-w-[640px] mb-7"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  if (githubTarget) goToReport(githubTarget.owner, githubTarget.repo);
+                }}
+              >
+                <label
+                  className="flex-1 flex items-center gap-2.5 rounded-lg px-3.5 transition-colors focus-within:border-cyan-500"
+                  style={{ background: "rgba(2,6,23,0.8)", border: "1px solid #1e293b" }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="opacity-50 flex-shrink-0">
+                    <circle cx="11" cy="11" r="7" />
+                    <path d="m20 20-4-4" />
+                  </svg>
+                  <input
+                    type="text"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Search skills — or paste any GitHub URL..."
+                    aria-label="Search the registry"
+                    className="flex-1 bg-transparent border-none outline-none text-slate-200 font-mono text-xs h-[42px] min-w-0 placeholder:text-slate-600"
+                  />
+                </label>
                 <button
-                  onClick={handleCompileOnTheFly}
-                  className="px-3.5 py-1.5 bg-cyan-950/50 border border-cyan-900 hover:border-cyan-800 text-[11px] font-bold text-cyan-400 rounded-lg transition-colors"
+                  type="submit"
+                  disabled={!githubTarget}
+                  className="inline-flex items-center rounded-lg text-xs font-semibold px-4 h-[42px] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  style={{ background: "rgba(8,51,68,0.8)", border: "1px solid #155e75", color: "#22d3ee" }}
                 >
-                  Compile this repository now
+                  Compile &amp; Scan
                 </button>
-              )}
+              </form>
             </div>
-          ) : (
-            <div className="flex flex-col gap-2.5 max-h-[500px] overflow-y-auto pr-1">
-              {skills.map((skill) => (
-                <a
-                  key={skill.repo_url}
-                  href={`/registry/${skill.owner}/${skill.repo}`}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    setSelectedSkillUrl(skill.repo_url);
-                    handleSelectSkill(skill.repo_url);
-                  }}
-                  className={`w-full text-left p-4 rounded-xl border transition-all duration-200 block ${
-                    selectedSkillUrl === skill.repo_url
-                      ? "bg-slate-950/60 border-cyan-500/40 shadow-[0_0_12px_rgba(6,182,212,0.06)]"
-                      : "bg-slate-950/30 border-slate-900 hover:border-slate-800 hover:bg-slate-950/40"
-                  }`}
-                >
-                  <div className="flex justify-between items-start mb-1.5">
-                    <span className="font-semibold text-xs tracking-wide text-slate-200">
-                      {skill.owner}/{skill.repo}
-                    </span>
-                    <span className={`text-[10px] font-bold px-2 py-0.5 border rounded-full ${getGradeBg(skill.grade)}`}>
-                      Grade {skill.grade}
-                    </span>
-                  </div>
-                  <p className="text-[11px] text-slate-400 line-clamp-2 mb-2">{skill.description}</p>
-                  <div className="flex justify-between items-center text-[10px] text-slate-500">
-                    <span>{skill.primary_languages.join(" · ")}</span>
-                    <span>{skill.files_analyzed} files</span>
-                  </div>
-                  {skill.scanned_at && (
-                    <div className="mt-1.5 text-[10px] text-slate-600">
-                      Scanned {skill.scanned_at.slice(0, 10)}
+
+            {/* Registry pulse */}
+            <div className="min-w-0 lg:min-w-[340px] mb-8 lg:mb-9">
+              <div className="rounded-2xl overflow-hidden" style={glassStyle} role="group" aria-label="Registry summary">
+                <div className="grid grid-cols-2 sm:grid-cols-4">
+                  {[
+                    { l: "Skills indexed", v: String(skills.length), s: `across ${pulse.langs} languages` },
+                    { l: "Gate pass rate", v: skills.length ? `${Math.round((pulse.passN / skills.length) * 100)}%` : "—", s: `${pulse.passN} of ${skills.length} pass` },
+                    { l: "Median risk", v: String(pulse.median), s: "weighted score" },
+                    { l: "Open findings", v: String(pulse.findings), s: "across all scans" },
+                  ].map((t, i) => (
+                    <div key={t.l} className="px-4 py-3.5" style={{ borderLeft: i > 0 ? "1px solid rgba(71,85,105,0.2)" : "none" }}>
+                      <Eyebrow>{t.l}</Eyebrow>
+                      <div className="font-mono tabular-nums text-[22px] font-semibold text-slate-100 mt-1 leading-tight">{t.v}</div>
+                      <div className="text-[11px] text-slate-500 mt-0.5">{t.s}</div>
                     </div>
-                  )}
-                  <div className="mt-2 text-[10px] font-semibold text-cyan-500 hover:text-cyan-400">
-                    View full report →
-                  </div>
-                </a>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Right Side: Detailed Security Audit and Preview */}
-        <div className="lg:col-span-7 bg-slate-950/40 border border-slate-900 rounded-2xl p-5 sm:p-6 flex flex-col">
-          {loadingDetail ? (
-            <div className="flex-grow flex flex-col items-center justify-center py-32">
-              <div className="w-6 h-6 border-2 border-cyan-500 border-t-transparent rounded-full animate-spin mb-4" />
-              <span className="text-xs text-slate-400">Compiling repository structure...</span>
-              <span className="text-[10px] text-slate-500 mt-1">Downloading, performing static analysis, and running security audit.</span>
-            </div>
-          ) : detailError ? (
-            <div className="flex-grow flex flex-col items-center justify-center py-32 px-6 text-center">
-              <svg className="w-8 h-8 text-rose-500 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <circle cx="12" cy="12" r="10" />
-                <path d="M12 8v4M12 16h.01" />
-              </svg>
-              <span className="text-xs font-semibold text-rose-400">Failed to compile skill</span>
-              <p className="text-[11px] text-slate-500 mt-1 max-w-[380px]">{detailError}</p>
-            </div>
-          ) : !detail ? (
-            <div className="flex-grow flex flex-col items-center justify-center py-32 text-center">
-              <svg className="w-10 h-10 text-slate-700 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 15l-6 6m0 0l-6-6m6 6V9a6 6 0 0112 0v3" />
-              </svg>
-              <span className="text-xs text-slate-500 font-semibold">Select a skill or enter a GitHub URL</span>
-              <p className="text-[10px] text-slate-600 mt-1">Get audited security reports and pre-compiled workspace skill markdown.</p>
-            </div>
-          ) : (
-            <div className="flex-grow flex flex-col gap-4">
-              {/* Skill Header Info */}
-              <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 border-b border-slate-900 pb-4">
-                <div>
-                  <h3 className="font-bold text-sm tracking-wide text-slate-200">{detail.owner}/{detail.repo}</h3>
-                  <a
-                    href={detail.repo_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-[11px] text-cyan-500 hover:underline flex items-center gap-1 mt-0.5"
-                  >
-                    {detail.repo_url}
-                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                    </svg>
-                  </a>
+                  ))}
                 </div>
-                <div className="flex gap-2">
-                  <span className={`text-xs font-bold px-3 py-1 border rounded-lg ${getGradeBg(detail.grade)}`}>
-                    Grade {detail.grade}
-                  </span>
-                  <button
-                    onClick={() => {
-                      navigator.clipboard.writeText(`npx gitscape ${detail.repo_url}`);
-                      alert("CLI command copied to clipboard!");
-                    }}
-                    className="px-3 py-1 bg-slate-900 border border-slate-800 text-[11px] font-bold text-slate-300 hover:border-slate-600 rounded-lg transition-colors flex items-center gap-1.5"
-                  >
-                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
-                    </svg>
-                    Copy command
-                  </button>
-                </div>
-              </div>
-
-              {/* Tabs */}
-              <div className="flex border-b border-slate-900">
-                {[
-                  { key: "findings", label: `Audit Report (${detail.findings.length})` },
-                  { key: "skill_md", label: "SKILL.md Preview" },
-                  { key: "manifest", label: "Provenance JSON" }
-                ].map((t) => (
-                  <button
-                    key={t.key}
-                    onClick={() => setActiveTab(t.key as any)}
-                    className={`px-4 py-2.5 text-xs font-semibold border-b-2 transition-all ${
-                      activeTab === t.key
-                        ? "border-cyan-500 text-cyan-400"
-                        : "border-transparent text-slate-400 hover:text-slate-200"
-                    }`}
-                  >
-                    {t.label}
-                  </button>
-                ))}
-              </div>
-
-              {/* Tab Contents */}
-              <div className="flex-grow max-h-[360px] overflow-y-auto pr-1">
-                {activeTab === "findings" && (
-                  <div className="flex flex-col gap-3">
-                    <div className="flex items-center justify-between text-xs text-slate-400 bg-slate-950/40 p-3 rounded-lg border border-slate-900">
-                      <span>ScapeGuard Verdict: <strong>{detail.status}</strong></span>
-                      <span>Risk Score: <strong>{detail.risk_score}</strong></span>
-                    </div>
-
-                    {detail.findings.length === 0 ? (
-                      <div className="text-center py-12 text-slate-500 text-xs">
-                        ✓ No vulnerabilities or prompt injections found. This skill is safe to load.
-                      </div>
-                    ) : (
-                      <div className="flex flex-col gap-2.5">
-                        {detail.findings.map((f, idx) => (
-                          <div key={idx} className="p-3 bg-slate-950/60 border border-slate-900 rounded-lg flex flex-col gap-1.5">
-                            <div className="flex justify-between items-center">
-                              <span className="text-[11px] font-bold text-rose-400 uppercase tracking-wide">
-                                [{f.severity}] {f.rule}
-                              </span>
-                              <span className="text-[10px] text-slate-500">
-                                {f.file}{f.line ? `:${f.line}` : ""}
-                              </span>
-                            </div>
-                            <p className="text-xs text-slate-300">{f.message}</p>
-                            {f.snippet && (
-                              <pre className="text-[10px] bg-slate-950 p-2 rounded border border-slate-900/60 overflow-x-auto text-slate-400 max-h-[80px]">
-                                <code>{f.snippet}</code>
-                              </pre>
-                            )}
-                          </div>
-                        ))}
-                      </div>
+                <div className="px-4 pb-4 pt-3" style={{ borderTop: "1px solid rgba(71,85,105,0.2)" }}>
+                  <div className="flex gap-0.5 h-1.5 rounded-sm overflow-hidden" title="Grade distribution">
+                    {(["A", "B", "C", "F"] as const).map(
+                      (g) =>
+                        counts[g] > 0 && <span key={g} style={{ flex: counts[g], background: gradeInfo(g).hex, display: "block" }} />
                     )}
                   </div>
-                )}
-
-                {activeTab === "skill_md" && (
-                  <div className="bg-slate-950/80 p-4 rounded-xl border border-slate-900 text-xs text-slate-300 font-mono whitespace-pre-wrap leading-relaxed">
-                    {detail.skill_md}
+                  <div className="flex flex-wrap gap-x-3 gap-y-1 mt-2">
+                    {(["A", "B", "C", "F"] as const).map((g) => (
+                      <span key={g} className="inline-flex items-center gap-1.5 font-mono text-[9.5px] tracking-[0.06em] text-slate-400 tabular-nums">
+                        <i style={{ width: 7, height: 7, borderRadius: 2, background: gradeInfo(g).hex, display: "inline-block" }} />
+                        {g} {counts[g]}
+                      </span>
+                    ))}
                   </div>
-                )}
-
-                {activeTab === "manifest" && (
-                  <pre className="bg-slate-950/80 p-4 rounded-xl border border-slate-900 text-[10px] text-slate-400 font-mono overflow-x-auto leading-normal">
-                    {JSON.stringify(detail.manifest, null, 2)}
-                  </pre>
-                )}
+                </div>
               </div>
             </div>
-          )}
+          </div>
         </div>
+      </div>
+
+      {/* ── Toolbar + results ─────────────────────────────────────── */}
+      <div className="max-w-[1180px] mx-auto px-4 sm:px-7">
+        <div className="flex items-center gap-3.5 py-4 flex-wrap">
+          <span className="font-mono text-[11px] tracking-[0.06em] text-slate-500 mr-auto">
+            {list.length} skill{list.length === 1 ? "" : "s"} · sorted by {sort}
+          </span>
+          <div className="flex gap-1.5" role="group" aria-label="Filter by grade">
+            {(["ALL", "A", "B", "C", "F"] as GradeFilter[]).map((g) => {
+              const on = grade === g;
+              return (
+                <button
+                  key={g}
+                  onClick={() => setGrade(g)}
+                  className="font-mono text-[11px] tracking-[0.04em] rounded-full px-3 py-1 transition-colors"
+                  style={
+                    on
+                      ? { background: "rgba(6,182,212,0.12)", border: "1px solid rgba(6,182,212,0.5)", color: "#67e8f9" }
+                      : { background: "rgba(30,41,59,0.4)", border: "1px solid rgba(71,85,105,0.35)", color: "#94a3b8" }
+                  }
+                >
+                  {g === "ALL" ? "All" : `Grade ${g}`}
+                  <span className="ml-1.5" style={{ color: on ? "rgba(103,232,249,0.75)" : "#64748b" }}>{counts[g]}</span>
+                </button>
+              );
+            })}
+          </div>
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as SortKey)}
+            aria-label="Sort order"
+            className="font-mono text-[11px] rounded-md px-2 py-1.5 text-slate-400"
+            style={{ background: "rgba(30,41,59,0.5)", border: "1px solid rgba(71,85,105,0.35)" }}
+          >
+            <option value="risk">Sort · risk ↑</option>
+            <option value="stars">Sort · stars ↓</option>
+            <option value="name">Sort · name A–Z</option>
+            <option value="scanned">Sort · newest scan</option>
+          </select>
+          <div className="flex rounded-md overflow-hidden" style={{ border: "1px solid rgba(71,85,105,0.35)" }} role="group" aria-label="Layout">
+            {(
+              [
+                ["grid", <svg key="g" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" /><rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" /></svg>],
+                ["list", <svg key="l" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M4 6h16M4 12h16M4 18h16" /></svg>],
+              ] as [Layout, React.ReactNode][]
+            ).map(([mode, icon]) => (
+              <button
+                key={mode}
+                onClick={() => setLayout(mode)}
+                aria-label={`${mode} view`}
+                title={`${mode} view`}
+                className="flex px-2.5 py-[7px] transition-colors"
+                style={layout === mode ? { background: "rgba(30,41,59,0.9)", color: "#22d3ee" } : { background: "none", color: "#64748b" }}
+              >
+                {icon}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3.5 pb-14">
+            {[1, 2, 3, 4, 5, 6].map((i) => (
+              <div key={i} className="rounded-2xl p-5 animate-pulse h-[180px]" style={glassStyle} />
+            ))}
+          </div>
+        ) : list.length === 0 ? (
+          <div className="rounded-2xl text-center px-5 py-14 mb-14" style={glassStyle}>
+            <p className="font-semibold text-slate-200 mb-1.5">No indexed skill matches “{query}”</p>
+            <p className="text-xs text-slate-500 mb-4">
+              Paste a GitHub URL above and ScapeGuard will compile and scan it on the fly.
+            </p>
+            {githubTarget && (
+              <button
+                onClick={() => goToReport(githubTarget.owner, githubTarget.repo)}
+                className="inline-flex items-center rounded-lg text-xs font-semibold px-4 py-2.5"
+                style={{ background: "rgba(8,51,68,0.8)", border: "1px solid #155e75", color: "#22d3ee" }}
+              >
+                Compile this repository now
+              </button>
+            )}
+          </div>
+        ) : layout === "grid" ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3.5 pb-14">
+            {list.map((s) => (
+              <a
+                key={s.repo_url}
+                href={`/registry/${s.owner}/${s.repo}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  goToReport(s.owner, s.repo);
+                }}
+                aria-label={`Open security report for ${s.owner}/${s.repo}`}
+                className="flex flex-col gap-3 rounded-2xl p-[18px] pb-[15px] transition-all duration-150 hover:-translate-y-0.5"
+                style={glassStyle}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.borderColor = "rgba(6,182,212,0.4)";
+                  e.currentTarget.style.boxShadow = "0 0 12px rgba(6,182,212,0.06), 0 12px 32px -18px rgba(0,0,0,0.9)";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.borderColor = "rgba(71,85,105,0.2)";
+                  e.currentTarget.style.boxShadow = "none";
+                }}
+              >
+                <div className="flex items-start gap-3">
+                  <RepoMark owner={s.owner} repo={s.repo} grade={s.grade} size={44} />
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-semibold text-[14.5px] text-slate-200 leading-tight whitespace-nowrap overflow-hidden text-ellipsis">
+                      <span className="text-slate-500 font-normal">{s.owner} /</span> {s.repo}
+                    </span>
+                    <span className="block font-mono text-[10.5px] text-slate-500 mt-1 tracking-[0.03em]">
+                      {(s.primary_languages || []).join(" · ")} · {(s.files_analyzed || 0).toLocaleString()} files
+                    </span>
+                  </span>
+                  <GradeSeal grade={s.grade} size={40} />
+                </div>
+                <p className="text-xs text-slate-400 leading-normal m-0 line-clamp-2 min-h-[2.9em]">{s.description}</p>
+                <div className="flex items-center gap-2" title={`Gate verdict: ${s.status} · ${s.findings_count} findings`}>
+                  <i style={{ width: 7, height: 7, borderRadius: 2, background: statusColor(s.status), display: "inline-block" }} />
+                  <span className="font-mono text-[10px] tracking-[0.05em]" style={{ color: statusColor(s.status) }}>
+                    {s.status}
+                  </span>
+                  <span className="font-mono text-[10px] text-slate-500 tracking-[0.05em]">
+                    · {s.findings_count} finding{s.findings_count === 1 ? "" : "s"}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between pt-2.5" style={{ borderTop: "1px solid rgba(71,85,105,0.2)" }}>
+                  <span className="font-mono text-[10.5px] text-slate-500 tabular-nums">{cardMeta(s)}</span>
+                  <RiskBar risk={s.risk_score} grade={s.grade} />
+                </div>
+              </a>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-2xl overflow-hidden mb-14" style={glassStyle}>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse min-w-[560px]" style={{ tableLayout: "fixed" }}>
+                <thead>
+                  <tr style={{ background: "rgba(30,41,59,0.5)", borderBottom: "1px solid rgba(71,85,105,0.35)" }}>
+                    <th className="w-[34px] px-3.5 py-3 text-left font-mono text-[10px] font-semibold tracking-[0.14em] uppercase text-slate-500">#</th>
+                    <th className="px-3.5 py-3 text-left font-mono text-[10px] font-semibold tracking-[0.14em] uppercase text-slate-500">Skill</th>
+                    <th className="w-[110px] px-3.5 py-3 text-left font-mono text-[10px] font-semibold tracking-[0.14em] uppercase text-slate-500">Language</th>
+                    <th className="w-[110px] px-3.5 py-3 text-right font-mono text-[10px] font-semibold tracking-[0.14em] uppercase text-slate-500">Risk</th>
+                    <th className="w-[130px] px-3.5 py-3 text-right font-mono text-[10px] font-semibold tracking-[0.14em] uppercase text-slate-500">Grade</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {list.map((s, i) => (
+                    <tr
+                      key={s.repo_url}
+                      onClick={() => goToReport(s.owner, s.repo)}
+                      onKeyDown={(e) => e.key === "Enter" && goToReport(s.owner, s.repo)}
+                      tabIndex={0}
+                      role="link"
+                      aria-label={`Open report for ${s.owner}/${s.repo}`}
+                      className="cursor-pointer transition-colors hover:bg-slate-800/40"
+                      style={{ borderBottom: i < list.length - 1 ? "1px solid rgba(71,85,105,0.2)" : "none" }}
+                    >
+                      <td className="px-3.5 py-3 font-mono text-[10.5px] text-slate-500 tabular-nums">{String(i + 1).padStart(2, "0")}</td>
+                      <td className="px-3.5 py-3">
+                        <span className="flex items-center gap-3 min-w-0">
+                          <RepoMark owner={s.owner} repo={s.repo} grade={s.grade} size={30} />
+                          <span className="min-w-0 flex-1">
+                            <span className="block font-semibold text-[12.5px] text-slate-200 whitespace-nowrap overflow-hidden text-ellipsis">
+                              <span className="text-slate-500 font-normal">{s.owner} /</span> {s.repo}
+                            </span>
+                            <span className="block text-[11.5px] text-slate-500 whitespace-nowrap overflow-hidden text-ellipsis mt-px">
+                              {s.description}
+                            </span>
+                          </span>
+                        </span>
+                      </td>
+                      <td className="px-3.5 py-3 font-mono text-[11px] text-slate-400 whitespace-nowrap">
+                        {(s.primary_languages || [])[0] || "—"}
+                        {(s.primary_languages || []).length > 1 ? ` +${s.primary_languages.length - 1}` : ""}
+                      </td>
+                      <td className="px-3.5 py-3 text-right">
+                        <RiskBar risk={s.risk_score} grade={s.grade} />
+                      </td>
+                      <td className="px-3.5 py-3 text-right">
+                        <GradeChip grade={s.grade} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/components/RepoReportPage.tsx
+++ b/frontend/components/RepoReportPage.tsx
@@ -1,5 +1,28 @@
-import React, { useState, useEffect, useRef } from "react";
-import { ScanFinding } from "../types";
+// Author: Joao Machete
+// Description: Per-repo security audit report — Aurora design. An audit-document
+// layout: certificate of audit with animated grade seal, KPI instrument tiles,
+// gate-category verdicts, severity profile, expandable findings ledger, and
+// provenance/distribution (scan-report.json, README badge, install command).
+import React, { useState, useEffect } from "react";
+import { ScanFinding, CategoryResult } from "../types";
+import {
+  gradeInfo,
+  sevColor,
+  statusColor,
+  SEV_ORDER,
+  CAT_LABEL,
+  DEFAULT_CATEGORIES,
+  fmtK,
+  glassStyle,
+  codeSurfaceStyle,
+  Eyebrow,
+  SectionTitle,
+  GradeSeal,
+  GradeChip,
+  StatusChip,
+  SevPill,
+  CopyButton,
+} from "./registryTheme";
 
 interface RepoReportData {
   repo_url: string;
@@ -13,7 +36,7 @@ interface RepoReportData {
   status: string;
   risk_score: number;
   findings: ScanFinding[];
-  categories: { category: string; status: string; findings: number }[];
+  categories: CategoryResult[];
   skill_md?: string;
   scanned_at?: string;
   findings_count?: number;
@@ -27,107 +50,38 @@ interface RepoReportData {
   last_git_sha?: string;
 }
 
-
 interface RepoReportPageProps {
   owner: string;
   repo: string;
   onNavigate: (path: string, hash?: string) => void;
 }
 
-// ── Animated radial security gauge ───────────────────────────────────────────
-const SecurityGauge: React.FC<{ grade: string }> = ({ grade }) => {
-  const gaugeRef = useRef<SVGCircleElement>(null);
-  const RADIUS = 52;
-  const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
-  const scoreMap: Record<string, number> = { A: 95, B: 75, C: 55, F: 20, "?": 0 };
-  const score = scoreMap[grade] ?? 0;
-  const offset = CIRCUMFERENCE - (score / 100) * CIRCUMFERENCE;
-  const colorMap: Record<string, string> = {
-    A: "#10b981", B: "#84cc16", C: "#f59e0b", F: "#ef4444", "?": "#64748b",
-  };
-  const color = colorMap[grade] ?? "#64748b";
+type FindSort = "severity" | "rule" | "file";
 
-  useEffect(() => {
-    if (gaugeRef.current) {
-      gaugeRef.current.style.transition = "none";
-      gaugeRef.current.style.strokeDashoffset = String(CIRCUMFERENCE);
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (gaugeRef.current) {
-            gaugeRef.current.style.transition = "stroke-dashoffset 1.4s cubic-bezier(0.4,0,0.2,1)";
-            gaugeRef.current.style.strokeDashoffset = String(offset);
-          }
-        });
-      });
-    }
-  }, [grade, offset, CIRCUMFERENCE]);
+const SEV_RANK: Record<string, number> = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3, INFO: 4 };
 
-  return (
-    <div className="flex flex-col items-center">
-      <svg width="130" height="130" viewBox="0 0 130 130">
-        <circle cx="65" cy="65" r={RADIUS} fill="none" stroke="rgba(71,85,105,0.2)" strokeWidth="10" />
-        <defs>
-          <filter id="gauge-glow">
-            <feGaussianBlur stdDeviation="3" result="coloredBlur" />
-            <feMerge>
-              <feMergeNode in="coloredBlur" />
-              <feMergeNode in="SourceGraphic" />
-            </feMerge>
-          </filter>
-        </defs>
-        <circle
-          ref={gaugeRef}
-          cx="65" cy="65" r={RADIUS} fill="none"
-          stroke={color} strokeWidth="10" strokeLinecap="round"
-          strokeDasharray={CIRCUMFERENCE}
-          strokeDashoffset={CIRCUMFERENCE}
-          transform="rotate(-90 65 65)"
-          filter="url(#gauge-glow)"
-        />
-        <text x="65" y="60" textAnchor="middle" fontSize="36" fontWeight="800" fill={color} fontFamily="Inter, sans-serif">{grade}</text>
-        <text x="65" y="80" textAnchor="middle" fontSize="11" fontWeight="600" fill="#64748b" fontFamily="Inter, sans-serif">GRADE</text>
-      </svg>
-    </div>
-  );
+const SkeletonCard: React.FC<{ h?: number }> = ({ h = 120 }) => (
+  <div className="rounded-2xl animate-pulse" style={{ ...glassStyle, height: h }} />
+);
+
+// Category verdicts fall back to grade-derived statuses when a cached report
+// predates the categories field (mirrors the backend badge-page fallback).
+const resolveCategories = (data: RepoReportData): CategoryResult[] => {
+  if (data.categories && data.categories.length > 0) return data.categories;
+  return DEFAULT_CATEGORIES.map((cat) => {
+    let status: CategoryResult["status"] = "PASS";
+    if (data.grade === "F" && (cat === "secrets" || cat === "prompt_injection")) status = "FAIL";
+    else if (["B", "C"].includes(data.grade) && cat === "prompt_injection") status = "WARN";
+    return { category: cat, status, findings: status === "PASS" ? 0 : 1 };
+  });
 };
 
-const SkeletonCard: React.FC = () => (
-  <div className="rounded-2xl p-6 animate-pulse" style={{ background: "rgba(15,23,42,0.6)", border: "1px solid rgba(71,85,105,0.2)" }}>
-    <div className="h-4 rounded mb-3 w-1/3" style={{ background: "rgba(71,85,105,0.3)" }} />
-    <div className="h-8 rounded mb-2 w-1/2" style={{ background: "rgba(71,85,105,0.2)" }} />
-    <div className="h-3 rounded w-2/3" style={{ background: "rgba(71,85,105,0.15)" }} />
-  </div>
-);
-
-const gradeColor = (g: string) => ({ A: "#10b981", B: "#84cc16", C: "#f59e0b", F: "#ef4444" }[g] ?? "#64748b");
-const gradeLabel = (g: string) => ({ A: "Excellent", B: "Good", C: "Moderate", F: "High Risk" }[g] ?? "Unknown");
-const sevColor = (s: string) =>
-  ({ CRITICAL: "#ef4444", HIGH: "#f97316", MEDIUM: "#f59e0b", LOW: "#64748b", INFO: "#3b82f6" }[(s || "").toUpperCase()] ?? "#64748b");
-
-const SectionTitle: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <h2 className="text-base font-bold text-slate-200 flex items-center gap-2 mb-4">
-    <span style={{ display: "inline-block", width: 3, height: 16, borderRadius: 2, background: "linear-gradient(#7c3aed, #22d3ee)", flexShrink: 0 }} />
-    {children}
-  </h2>
-);
-
-const GlassCard: React.FC<{ children: React.ReactNode; className?: string }> = ({ children, className = "" }) => (
-  <div
-    className={`rounded-xl p-5 ${className}`}
-    style={{ background: "rgba(15,23,42,0.6)", border: "1px solid rgba(71,85,105,0.2)" }}
-  >
-    {children}
-  </div>
-);
-
-// ── Main component ────────────────────────────────────────────────────────────
 export const RepoReportPage: React.FC<RepoReportPageProps> = ({ owner, repo, onNavigate }) => {
   const [data, setData] = useState<RepoReportData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [sortField, setSortField] = useState<"severity" | "rule" | "file">("severity");
-  const [copied, setCopied] = useState(false);
-  const [expandedFinding, setExpandedFinding] = useState<number | null>(null);
+  const [findSort, setFindSort] = useState<FindSort>("severity");
+  const [expanded, setExpanded] = useState<number | null>(null);
 
   const repoUrl = `https://github.com/${owner}/${repo}`;
   const pageUrl = `https://gitscape.ai/registry/${owner}/${repo}`;
@@ -141,6 +95,7 @@ export const RepoReportPage: React.FC<RepoReportPageProps> = ({ owner, repo, onN
     setLoading(true);
     setError(null);
     setData(null);
+    setExpanded(null);
     fetch(getApiUrl(`/registry/detail?repo_url=${encodeURIComponent(repoUrl)}`))
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -154,7 +109,8 @@ export const RepoReportPage: React.FC<RepoReportPageProps> = ({ owner, repo, onN
         document.title = `${owner}/${repo} Security Audit — Grade ${grade} | GitScape AI`;
         const metaDesc = document.querySelector('meta[name="description"]');
         if (metaDesc) {
-          metaDesc.setAttribute("content",
+          metaDesc.setAttribute(
+            "content",
             `${owner}/${repo} received Grade ${grade} in the GitScape ScapeGuard security audit — ${count} finding${count !== 1 ? "s" : ""} across ${d.files_analyzed} files. Languages: ${langs}.`
           );
         }
@@ -167,25 +123,32 @@ export const RepoReportPage: React.FC<RepoReportPageProps> = ({ owner, repo, onN
     };
   }, [owner, repo]);
 
-  const copyBadge = () => {
-    const grade = data?.grade ?? "?";
-    navigator.clipboard.writeText(`[![ScapeGuard Grade ${grade}](https://gitscape.ai/api/badge/${owner}/${repo})](${pageUrl})`);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+  const G = gradeInfo(data?.grade);
+  const findings = data?.findings || [];
+  const sevCounts: Record<string, number> = { CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0, INFO: 0 };
+  findings.forEach((f) => {
+    const s = (f.severity || "").toUpperCase();
+    if (sevCounts[s] !== undefined) sevCounts[s]++;
+  });
+  const categories = data ? resolveCategories(data) : [];
+  const gatesPassed = categories.filter((c) => c.status === "PASS").length;
 
-  const sortedFindings = data
-    ? [...(data.findings || [])].sort((a, b) => {
-        const sevOrder: Record<string, number> = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3, INFO: 4 };
-        if (sortField === "severity") return (sevOrder[(a.severity || "").toUpperCase()] ?? 9) - (sevOrder[(b.severity || "").toUpperCase()] ?? 9);
-        if (sortField === "rule") return (a.rule ?? "").localeCompare(b.rule ?? "");
-        return (a.file ?? "").localeCompare(b.file ?? "");
-      })
-    : [];
+  const sortedFindings = [...findings].sort((a, b) => {
+    if (findSort === "severity")
+      return (SEV_RANK[(a.severity || "").toUpperCase()] ?? 9) - (SEV_RANK[(b.severity || "").toUpperCase()] ?? 9);
+    if (findSort === "rule") return (a.rule ?? "").localeCompare(b.rule ?? "");
+    return (a.file ?? "").localeCompare(b.file ?? "");
+  });
+
+  const badgeMarkdown = data
+    ? `[![ScapeGuard ${data.grade}](https://gitscape.ai/api/badge/${owner}/${repo})](${pageUrl})`
+    : "";
+  const installCmd = `npx gitscape ${repoUrl}`;
+  const sha = data?.last_git_sha ? data.last_git_sha.slice(0, 12) : "—";
 
   return (
     <div className="min-h-screen" style={{ background: "#0b1120" }}>
-      {/* ── Hero band ───────────────────────────────────────────────── */}
+      {/* ── Hero band ─────────────────────────────────────────────── */}
       <div
         className="relative overflow-hidden"
         style={{
@@ -196,336 +159,428 @@ export const RepoReportPage: React.FC<RepoReportPageProps> = ({ owner, repo, onN
         <div style={{ position: "absolute", top: -80, right: -80, width: 400, height: 400, borderRadius: "50%", background: "radial-gradient(circle, rgba(124,58,237,0.12), transparent 70%)", pointerEvents: "none" }} />
         <div style={{ position: "absolute", bottom: -60, left: 80, width: 300, height: 300, borderRadius: "50%", background: "radial-gradient(circle, rgba(6,182,212,0.08), transparent 70%)", pointerEvents: "none" }} />
 
-        <div className="max-w-[1100px] mx-auto px-4 sm:px-6 py-10 sm:py-14 relative">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <button onClick={() => onNavigate("/")} className="hover:text-slate-300 transition-colors">GitScape AI</button>
-            <span>›</span>
-            <button onClick={() => onNavigate("/registry")} className="hover:text-slate-300 transition-colors">Registry</button>
-            <span>›</span>
-            <span className="text-cyan-400 font-semibold">{owner}/{repo}</span>
+        <div className="max-w-[1180px] mx-auto px-4 sm:px-7 py-7 relative">
+          <nav className="flex items-center gap-2 font-mono text-[11px] text-slate-500 mb-5" aria-label="Breadcrumb">
+            <button onClick={() => onNavigate("/")} className="hover:text-cyan-300 transition-colors">gitscape.ai</button>
+            <span>/</span>
+            <button onClick={() => onNavigate("/registry")} className="hover:text-cyan-300 transition-colors">registry</button>
+            <span>/</span>
+            <span className="text-slate-400">{owner}/{repo}</span>
           </nav>
 
           {loading ? (
             <div className="flex flex-col gap-4">
               <div className="h-9 w-72 rounded-lg animate-pulse" style={{ background: "rgba(71,85,105,0.3)" }} />
-              <div className="h-4 w-96 rounded animate-pulse" style={{ background: "rgba(71,85,105,0.2)" }} />
+              <div className="h-4 w-96 max-w-full rounded animate-pulse" style={{ background: "rgba(71,85,105,0.2)" }} />
             </div>
-          ) : (
+          ) : data ? (
             <>
-              <h1 className="text-3xl sm:text-4xl font-extrabold tracking-tight mb-3" style={{ color: "#f1f5f9", letterSpacing: "-1px" }}>
+              <Eyebrow>Security audit report · {sha}</Eyebrow>
+              <h1 className="text-2xl sm:text-3xl font-extrabold mt-1 mb-2" style={{ letterSpacing: "-1px", lineHeight: 1.15, color: "#f1f5f9" }}>
                 <span style={{ color: "#22d3ee" }}>{owner}</span>
-                <span style={{ color: "#475569" }}> / </span>
+                <span style={{ color: "#475569", fontWeight: 400 }}> / </span>
                 {repo}
               </h1>
-              {data && <p className="text-[15px] text-slate-400 max-w-2xl mb-4">{data.description}</p>}
-              
-              {data && data.ai_summary && (
-                <div 
-                  className="mb-6 p-4 rounded-xl max-w-3xl border"
-                  style={{
-                    background: "rgba(30,41,59,0.3)",
-                    borderColor: "rgba(71,85,105,0.2)"
-                  }}
-                >
-                  <p className="text-sm italic text-slate-300 leading-relaxed">
-                    🛡 &ldquo;{data.ai_summary}&rdquo;
-                  </p>
+              <p className="text-[14.5px] text-slate-400 max-w-[62ch] mb-3.5">{data.description}</p>
+
+              {data.ai_summary && (
+                <div className="rounded-xl px-4 py-3.5 mb-4 max-w-3xl" style={{ background: "rgba(30,41,59,0.3)", border: "1px solid rgba(71,85,105,0.2)" }}>
+                  <p className="text-[13px] italic text-slate-300 leading-relaxed m-0">🛡 &ldquo;{data.ai_summary}&rdquo;</p>
+                  <span className="block font-mono not-italic text-[10px] tracking-[0.12em] uppercase text-slate-500 mt-2">
+                    ScapeGuard analyst summary · generated from scan evidence
+                  </span>
                 </div>
               )}
 
-              <div className="flex flex-wrap gap-2 mb-7">
-                {data && (
-                  <>
-                    <span className="text-xs font-semibold px-3 py-1 rounded-full" style={{ background: "rgba(30,41,59,0.7)", border: "1px solid rgba(71,85,105,0.35)", color: "#94a3b8" }}>
-                      📅 {data.scanned_at ? `Scanned ${data.scanned_at.slice(0, 10)}` : "Scan date unknown"}
-                    </span>
-                    <span className="text-xs font-semibold px-3 py-1 rounded-full" style={{ background: "rgba(30,41,59,0.7)", border: "1px solid rgba(71,85,105,0.35)", color: "#94a3b8" }}>
-                      📁 {data.files_analyzed} files
-                    </span>
-                    {data.stars !== undefined && data.stars > 0 && (
-                      <span className="text-xs font-semibold px-3 py-1 rounded-full" style={{ background: "rgba(30,41,59,0.7)", border: "1px solid rgba(71,85,105,0.35)", color: "#94a3b8" }}>
-                        ⭐ {data.stars.toLocaleString()} stars
-                      </span>
-                    )}
-                    {data.forks !== undefined && data.forks > 0 && (
-                      <span className="text-xs font-semibold px-3 py-1 rounded-full" style={{ background: "rgba(30,41,59,0.7)", border: "1px solid rgba(71,85,105,0.35)", color: "#94a3b8" }}>
-                        🍴 {data.forks.toLocaleString()} forks
-                      </span>
-                    )}
-                    {data.license && (
-                      <span className="text-xs font-semibold px-3 py-1 rounded-full" style={{ background: "rgba(30,41,59,0.7)", border: "1px solid rgba(71,85,105,0.35)", color: "#94a3b8" }}>
-                        ⚖️ {data.license}
-                      </span>
-                    )}
-                    {data.primary_languages.map((l) => (
-                      <span key={l} className="text-xs font-semibold px-3 py-1 rounded-full" style={{ background: "rgba(30,41,59,0.7)", border: "1px solid rgba(71,85,105,0.35)", color: "#94a3b8" }}>{l}</span>
-                    ))}
-                    <span className="text-xs font-bold px-3 py-1 rounded-full" style={{ background: `${gradeColor(data.grade)}11`, border: `1px solid ${gradeColor(data.grade)}44`, color: gradeColor(data.grade) }}>
-                      🛡 Grade {data.grade} · {gradeLabel(data.grade)}
-                    </span>
-                  </>
-                )}
+              <div className="flex flex-wrap gap-2 mb-4">
+                {data.scanned_at && <span className="fact-pill">📅 Scanned {data.scanned_at.slice(0, 10)}</span>}
+                <span className="fact-pill">📁 {data.files_analyzed.toLocaleString()} files</span>
+                {!!data.stars && <span className="fact-pill">⭐ {fmtK(data.stars)} stars</span>}
+                {!!data.forks && <span className="fact-pill">🍴 {fmtK(data.forks)} forks</span>}
+                {data.license && <span className="fact-pill">⚖️ {data.license}</span>}
+                {(data.primary_languages || []).map((l) => (
+                  <span key={l} className="fact-pill">{l}</span>
+                ))}
+                <span className="fact-pill" style={{ color: G.hex, borderColor: `${G.hex}44`, background: `${G.hex}11` }}>
+                  🛡 Grade {data.grade} · {G.label}
+                </span>
               </div>
 
-              <div className="flex flex-wrap gap-3">
-                <a href={repoUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-semibold" style={{ background: "rgba(30,41,59,0.7)", border: "1px solid rgba(71,85,105,0.4)", color: "#94a3b8" }}>
+              <div className="flex flex-wrap gap-2.5">
+                <a
+                  href={repoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-lg text-xs font-semibold px-3.5 py-2"
+                  style={{ background: "rgba(30,41,59,0.7)", border: "1px solid rgba(71,85,105,0.4)", color: "#94a3b8" }}
+                >
                   View on GitHub ↗
                 </a>
-                <button onClick={() => onNavigate("/registry")} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-semibold" style={{ background: "rgba(30,41,59,0.5)", border: "1px solid rgba(71,85,105,0.3)", color: "#64748b" }}>
+                <button
+                  onClick={() => onNavigate("/registry")}
+                  className="inline-flex items-center gap-2 rounded-lg text-xs font-semibold px-3.5 py-2"
+                  style={{ background: "rgba(30,41,59,0.5)", border: "1px solid rgba(71,85,105,0.3)", color: "#64748b" }}
+                >
                   ← Registry
                 </button>
               </div>
             </>
-          )}
+          ) : null}
         </div>
       </div>
 
-      {/* ── Score cards ──────────────────────────────────────────────── */}
-      <div className="max-w-[1100px] mx-auto px-4 sm:px-6 py-8">
+      <div className="max-w-[1180px] mx-auto px-4 sm:px-7">
         {loading ? (
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-            {[1, 2, 3, 4].map((i) => <SkeletonCard key={i} />)}
+          <div className="grid grid-cols-1 lg:grid-cols-[340px_minmax(0,1fr)] gap-3.5 py-5">
+            <SkeletonCard h={420} />
+            <div className="flex flex-col gap-3.5">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3.5">
+                <SkeletonCard h={150} /><SkeletonCard h={150} /><SkeletonCard h={150} />
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3.5">
+                <SkeletonCard h={240} /><SkeletonCard h={240} />
+              </div>
+            </div>
           </div>
         ) : error ? (
-          <div className="rounded-2xl p-8 text-center mb-8" style={{ background: "rgba(239,68,68,0.06)", border: "1px solid rgba(239,68,68,0.2)" }}>
+          <div className="rounded-2xl p-8 text-center my-8" style={{ background: "rgba(239,68,68,0.06)", border: "1px solid rgba(239,68,68,0.2)" }}>
             <div className="text-rose-400 font-semibold mb-1">Failed to load report</div>
             <p className="text-xs text-slate-500">{error}</p>
-            <button onClick={() => onNavigate("/registry")} className="mt-4 text-xs text-cyan-400 hover:underline">← Back to Registry</button>
+            <button onClick={() => onNavigate("/registry")} className="mt-4 text-xs text-cyan-400 hover:underline">
+              ← Back to Registry
+            </button>
           </div>
         ) : data ? (
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8 items-start">
-            <div className="grid grid-cols-2 gap-4">
-              {/* Gauge */}
+          <>
+            {/* ── Certificate + KPI instruments ─────────────────────── */}
+            <div className="grid grid-cols-1 lg:grid-cols-[340px_minmax(0,1fr)] gap-3.5 pt-5 items-stretch">
               <div
-                className="rounded-2xl p-5 flex flex-col items-center justify-center col-span-2 sm:col-span-1"
-                style={{ background: "rgba(15,23,42,0.7)", border: `1px solid ${gradeColor(data.grade)}22`, boxShadow: `0 0 40px -8px ${gradeColor(data.grade)}22` }}
+                className="rounded-2xl flex flex-col items-center text-center relative overflow-hidden px-5 pt-6 pb-4"
+                style={{ ...glassStyle, borderColor: `${G.hex}22`, boxShadow: `0 0 40px -8px ${G.hex}22` }}
               >
-                <SecurityGauge grade={data.grade} />
-                <span className="text-sm font-bold mt-1" style={{ color: gradeColor(data.grade) }}>{gradeLabel(data.grade)}</span>
-              </div>
-
-              {[
-                {
-                  label: "Risk Score",
-                  value: data.risk_score,
-                  color: data.risk_score > 15 ? "text-rose-400" : data.risk_score > 5 ? "text-amber-400" : "text-emerald-400",
-                  sub: data.risk_score > 15 ? "High Risk" : data.risk_score > 5 ? "Moderate" : "Low Risk",
-                },
-                {
-                  label: "Findings",
-                  value: data.findings.length,
-                  color: data.findings.length > 0 ? "text-orange-400" : "text-emerald-400",
-                  sub: data.findings.length > 0 ? "Issues found" : "Clean",
-                },
-              ].map(({ label, value, color, sub }) => (
-                <div key={label} className="rounded-2xl p-5 flex flex-col items-center justify-center" style={{ background: "rgba(15,23,42,0.7)", border: "1px solid rgba(71,85,105,0.2)" }}>
-                  <span className="text-[10px] font-bold tracking-widest text-slate-500 uppercase mb-3">{label}</span>
-                  <span className={`text-5xl font-extrabold leading-none ${color}`}>{value}</span>
-                  <span className="text-xs text-slate-500 mt-2">{sub}</span>
-                </div>
-              ))}
-
-              {/* Verdict */}
-              <div className="rounded-2xl p-5 flex flex-col items-center justify-center col-span-2 sm:col-span-1" style={{ background: "rgba(15,23,42,0.7)", border: "1px solid rgba(71,85,105,0.2)" }}>
-                <span className="text-[10px] font-bold tracking-widest text-slate-500 uppercase mb-3">Verdict</span>
-                <span className="text-2xl font-extrabold" style={{ color: data.status === "PASS" ? "#10b981" : data.status === "WARN" ? "#f59e0b" : "#ef4444" }}>{data.status}</span>
-                <span className="text-xs text-slate-500 mt-2">ScapeGuard verdict</span>
-              </div>
-            </div>
-
-            {/* Mock scan-report.json editor card */}
-            <div 
-              className="rounded-2xl p-6 font-mono text-xs text-slate-400"
-              style={{ background: "#020617", border: "1px solid rgba(71,85,105,0.25)", boxShadow: "0 10px 40px rgba(0,0,0,0.6)" }}
-            >
-              <div className="flex justify-between items-center border-b border-slate-900 pb-3 mb-4">
-                <span className="font-semibold text-slate-200">scan-report.json</span>
-                <span 
-                  className="px-2 py-0.5 border rounded text-[10px] font-bold"
-                  style={{
-                    background: `${gradeColor(data.grade)}11`,
-                    borderColor: `${gradeColor(data.grade)}33`,
-                    color: gradeColor(data.grade)
-                  }}
-                >
-                  {data.grade} {data.status}
+                <div className="absolute rounded-lg pointer-events-none" style={{ inset: 8, border: "1px solid rgba(71,85,105,0.2)" }} />
+                <span className="font-mono text-[10px] tracking-[0.18em] uppercase text-slate-500">
+                  Certificate of audit · {sha}
                 </span>
-              </div>
-              <div className="flex flex-col gap-2">
-                <div className="flex justify-between">
-                  <span className="text-slate-500">"engine"</span>
-                  <span className="text-sky-400">"scapeguard/2.1.0"</span>
+                <div className="mt-4">
+                  <GradeSeal grade={data.grade} size={132} animate />
                 </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">"grade"</span>
-                  <span style={{ color: gradeColor(data.grade) }} className="font-bold">"{data.grade}"</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">"risk_score"</span>
-                  <span className="text-amber-500">{data.risk_score}</span>
-                </div>
-                {(() => {
-                  const defaultCategories = ["secrets", "prompt_injection", "malicious_execution", "supply_chain", "excessive_agency"];
-                  const categoriesToRender = data.categories && data.categories.length > 0 
-                    ? data.categories 
-                    : defaultCategories.map(cat => {
-                        let status = "PASS";
-                        if (data.grade === "F" && (cat === "secrets" || cat === "prompt_injection")) status = "FAIL";
-                        else if (["B", "C"].includes(data.grade) && cat === "prompt_injection") status = "WARN";
-                        return { category: cat, status, findings: status === "PASS" ? 0 : 1 };
-                      });
-                  return categoriesToRender.map((c) => {
-                    const catColor = c.status === "PASS" ? "text-emerald-400" : c.status === "WARN" ? "text-amber-400" : "text-rose-400";
-                    return (
-                      <div key={c.category} className="flex justify-between">
-                        <span className="text-slate-500">"{c.category}"</span>
-                        <span className={catColor}>"{c.status}"</span>
-                      </div>
-                    );
-                  });
-                })()}
-                <div className="flex justify-between">
-                  <span className="text-slate-500">"license"</span>
-                  <span className="text-slate-200">"{data.license || "Unknown"}"</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">"files_scanned"</span>
-                  <span className="text-emerald-400">{data.files_analyzed}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">"skill_hash"</span>
-                  <span className="text-slate-500">"{data.last_git_sha ? data.last_git_sha.slice(0, 12) : "9f2ce41a"}"</span>
+                <div className="text-[12.5px] font-semibold mt-2.5" style={{ color: G.hex }}>{G.label}</div>
+                <div className="mt-3.5 mb-1"><StatusChip status={data.status} size={12} /></div>
+                <dl className="w-full grid grid-cols-[auto_1fr] gap-x-3.5 gap-y-1.5 text-left mt-4 pt-3.5 m-0" style={{ borderTop: "1px solid rgba(71,85,105,0.2)" }}>
+                  {(
+                    [
+                      ["Engine", "scapeguard/2.1.0"],
+                      ["Commit", sha],
+                      ["Gates", `${gatesPassed}/5 pass`],
+                      ["Method", "deterministic gate"],
+                      ["Next scan", "on new commit"],
+                    ] as [string, string][]
+                  ).map(([k, v]) => (
+                    <React.Fragment key={k}>
+                      <dt className="font-mono text-[10px] tracking-[0.13em] uppercase text-slate-500 self-center">{k}</dt>
+                      <dd className="m-0 font-mono text-[11px] text-slate-400 text-right tabular-nums overflow-hidden text-ellipsis whitespace-nowrap">{v}</dd>
+                    </React.Fragment>
+                  ))}
+                </dl>
+                <div className="font-mono text-[9.5px] tracking-[0.1em] text-slate-500 mt-3">
+                  GRADE BANDS · A ≤ 0 · B ≤ 20 · C ≤ 50 · F &gt; 50 OR GATE FAIL
                 </div>
               </div>
-            </div>
-          </div>
-        ) : null}
 
-        {/* ── Findings table ─────────────────────────────────────────── */}
-        {data && (
-          <section className="mb-8">
-            <div className="flex items-center justify-between mb-4">
-              <SectionTitle>Security Findings</SectionTitle>
-              <div className="flex items-center gap-2 text-xs text-slate-500">
-                <span>Sort:</span>
-                {(["severity", "rule", "file"] as const).map((f) => (
-                  <button
-                    key={f}
-                    onClick={() => setSortField(f)}
-                    className="px-2.5 py-1 rounded-md font-semibold transition-colors"
-                    style={{
-                      background: sortField === f ? "rgba(124,58,237,0.15)" : "transparent",
-                      border: sortField === f ? "1px solid rgba(124,58,237,0.35)" : "1px solid transparent",
-                      color: sortField === f ? "#a78bfa" : "#64748b",
-                    }}
-                  >
-                    {f.charAt(0).toUpperCase() + f.slice(1)}
-                  </button>
-                ))}
-              </div>
-            </div>
+              <div className="flex flex-col gap-3.5 min-w-0">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3.5">
+                  {/* Risk score */}
+                  <div className="rounded-2xl p-5" style={glassStyle}>
+                    <Eyebrow>Risk score</Eyebrow>
+                    <div className="font-mono tabular-nums text-3xl font-semibold mt-2 mb-0.5" style={{ color: G.hex, letterSpacing: "-0.02em" }}>
+                      {data.risk_score}
+                    </div>
+                    <span className="text-[11.5px] text-slate-500">weighted severity, confidence-dampened</span>
+                    <div className="relative h-1.5 rounded-sm mt-3.5" style={{ background: "rgba(30,41,59,0.9)" }} role="img" aria-label={`Risk ${data.risk_score} on a 0 to 100 scale`}>
+                      <span className="absolute w-px" style={{ left: "20%", top: -3, bottom: -3, background: "rgba(71,85,105,0.35)" }} />
+                      <span className="absolute w-px" style={{ left: "50%", top: -3, bottom: -3, background: "rgba(71,85,105,0.35)" }} />
+                      <span
+                        className="absolute left-0 top-0 bottom-0 rounded-sm"
+                        style={{ width: `${Math.max(2, Math.min(100, data.risk_score))}%`, background: G.hex }}
+                      />
+                    </div>
+                    <div className="flex justify-between font-mono text-[9px] tracking-[0.08em] text-slate-500 mt-1.5">
+                      <span>0</span><span>B·20</span><span>C·50</span><span>100+</span>
+                    </div>
+                  </div>
 
-            {sortedFindings.length === 0 ? (
-              <div className="rounded-xl p-10 text-center" style={{ background: "rgba(16,185,129,0.05)", border: "1px solid rgba(16,185,129,0.2)" }}>
-                <div className="text-3xl mb-2">✓</div>
-                <p className="text-emerald-400 font-semibold text-sm">No security findings detected</p>
-                <p className="text-xs text-slate-500 mt-1">This repository is considered safe for agent installation.</p>
-              </div>
-            ) : (
-              <div className="rounded-xl overflow-hidden" style={{ background: "rgba(15,23,42,0.6)", border: "1px solid rgba(71,85,105,0.2)" }}>
-                <table className="w-full border-collapse">
-                  <thead>
-                    <tr style={{ borderBottom: "1px solid rgba(71,85,105,0.2)" }}>
-                      {["Severity", "Rule", "Description", "Location"].map((h) => (
-                        <th key={h} className="px-4 py-3 text-left text-[10px] font-bold tracking-widest text-slate-500 uppercase">{h}</th>
+                  {/* Findings */}
+                  <div className="rounded-2xl p-5" style={glassStyle}>
+                    <Eyebrow>Findings</Eyebrow>
+                    <div className="font-mono tabular-nums text-3xl font-semibold text-slate-100 mt-2 mb-0.5" style={{ letterSpacing: "-0.02em" }}>
+                      {findings.length}
+                    </div>
+                    <span className="text-[11.5px] text-slate-500">
+                      {findings.length === 0 ? "clean scan" : sevCounts.CRITICAL > 0 ? `${sevCounts.CRITICAL} unbypassable` : "all reviewable"}
+                    </span>
+                    <div className="flex gap-0.5 h-2 rounded-sm overflow-hidden mt-3.5" style={{ background: "rgba(30,41,59,0.9)" }} role="img" aria-label="Findings by severity">
+                      {findings.length === 0 ? (
+                        <i style={{ flex: 1, background: "#10b981", opacity: 0.35, display: "block" }} />
+                      ) : (
+                        SEV_ORDER.filter((s) => sevCounts[s] > 0).map((s) => (
+                          <i key={s} style={{ flex: sevCounts[s], background: sevColor(s), display: "block" }} />
+                        ))
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-x-3 gap-y-1 mt-2">
+                      {findings.length === 0 ? (
+                        <span className="micro-legend"><i style={{ background: "#10b981" }} />NONE</span>
+                      ) : (
+                        SEV_ORDER.filter((s) => sevCounts[s] > 0).map((s) => (
+                          <span key={s} className="micro-legend"><i style={{ background: sevColor(s) }} />{s} {sevCounts[s]}</span>
+                        ))
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Coverage */}
+                  <div className="rounded-2xl p-5" style={glassStyle}>
+                    <Eyebrow>Coverage</Eyebrow>
+                    <div className="font-mono tabular-nums text-3xl font-semibold text-slate-100 mt-2 mb-0.5" style={{ letterSpacing: "-0.02em" }}>
+                      {data.files_analyzed.toLocaleString()}
+                    </div>
+                    <span className="text-[11.5px] text-slate-500">files statically analyzed</span>
+                    <div className="mt-3.5 flex flex-wrap gap-1.5">
+                      {(data.primary_languages || []).map((l) => (
+                        <span key={l} className="font-mono text-[10.5px] text-slate-400 rounded px-2 py-0.5" style={{ border: "1px solid rgba(71,85,105,0.35)" }}>
+                          {l}
+                        </span>
                       ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedFindings.map((f, idx) => (
-                      <React.Fragment key={idx}>
-                        <tr
-                          onClick={() => setExpandedFinding(expandedFinding === idx ? null : idx)}
-                          className="cursor-pointer transition-colors"
-                          style={{
-                            borderBottom: idx < sortedFindings.length - 1 ? "1px solid rgba(71,85,105,0.1)" : "none",
-                            background: expandedFinding === idx ? "rgba(124,58,237,0.05)" : "transparent",
-                          }}
-                        >
-                          <td className="px-4 py-3">
-                            <span className="inline-block text-[10px] font-bold px-2.5 py-0.5 rounded-full" style={{ background: `${sevColor(f.severity)}15`, border: `1px solid ${sevColor(f.severity)}40`, color: sevColor(f.severity) }}>
-                              {(f.severity || "").toUpperCase()}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Gate categories + severity profile */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3.5 flex-grow">
+                  <div className="rounded-2xl p-5" style={glassStyle}>
+                    <SectionTitle sub="Deterministic PASS / WARN / FAIL per category">Gate categories</SectionTitle>
+                    <div className="mt-3">
+                      {categories.map((c, i) => (
+                        <div key={c.category} className="flex items-center gap-3 py-2.5" style={{ borderBottom: i < categories.length - 1 ? "1px solid rgba(71,85,105,0.2)" : "none" }}>
+                          <i style={{ width: 8, height: 8, borderRadius: 2, background: statusColor(c.status), flexShrink: 0 }} />
+                          <span className="font-mono text-[11.5px] text-slate-400 flex-1 tracking-[0.02em]">
+                            {CAT_LABEL[c.category] || c.category}
+                          </span>
+                          <span className="font-mono text-[10.5px] text-slate-500 tabular-nums">
+                            {c.findings > 0 ? `${c.findings} finding${c.findings > 1 ? "s" : ""}` : "—"}
+                          </span>
+                          <StatusChip status={c.status} />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl p-5" style={glassStyle}>
+                    <SectionTitle sub={`${findings.length} finding${findings.length === 1 ? "" : "s"} by severity`}>Severity profile</SectionTitle>
+                    <div className="flex flex-col gap-2.5 mt-4">
+                      {SEV_ORDER.map((s) => {
+                        const max = Math.max(...SEV_ORDER.map((k) => sevCounts[k]), 1);
+                        return (
+                          <div key={s} className="grid grid-cols-[76px_1fr_30px] items-center gap-3">
+                            <span className="font-mono text-[10px] tracking-[0.1em]" style={{ color: sevCounts[s] > 0 ? sevColor(s) : "#64748b" }}>{s}</span>
+                            <span className="h-2.5 relative">
+                              <span
+                                className="block h-2.5"
+                                style={{
+                                  width: sevCounts[s] === 0 ? 2 : `${(sevCounts[s] / max) * 100}%`,
+                                  minWidth: 2,
+                                  background: sevColor(s),
+                                  opacity: sevCounts[s] === 0 ? 0.18 : 1,
+                                  borderRadius: "0 4px 4px 0",
+                                }}
+                              />
                             </span>
-                          </td>
-                          <td className="px-4 py-3 font-mono text-[11px] text-slate-400">{f.rule}</td>
-                          <td className="px-4 py-3 text-xs text-slate-300 max-w-xs">
-                            <span className="line-clamp-2">{f.message}</span>
-                          </td>
-                          <td className="px-4 py-3 font-mono text-[10px] text-slate-500">{f.file}{f.line ? `:${f.line}` : ""}</td>
-                        </tr>
-                        {expandedFinding === idx && (f.snippet || f.remediation) && (
-                          <tr style={{ background: "rgba(8,13,20,0.8)", borderBottom: idx < sortedFindings.length - 1 ? "1px solid rgba(71,85,105,0.1)" : "none" }}>
-                            <td colSpan={4} className="px-4 pb-3 pt-1">
-                              {f.remediation && <p className="text-xs text-amber-400 mb-2 font-medium">💡 {f.remediation}</p>}
-                              {f.snippet && (
-                                <pre className="text-[10px] text-slate-400 overflow-x-auto leading-relaxed p-3 rounded-lg" style={{ background: "rgba(8,13,20,0.9)", border: "1px solid rgba(71,85,105,0.15)", maxHeight: 120 }}>
-                                  <code>{f.snippet}</code>
-                                </pre>
-                              )}
+                            <span className="font-mono text-[11px] text-slate-400 text-right tabular-nums">{sevCounts[s]}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* ── Findings ledger ───────────────────────────────────── */}
+            <div className="rounded-2xl mt-3.5 overflow-hidden" style={glassStyle}>
+              <div className="flex items-baseline gap-3.5 flex-wrap px-5 pt-5 pb-3.5">
+                <SectionTitle>Findings ledger</SectionTitle>
+                <span className="text-[11.5px] text-slate-500">
+                  {findings.length} finding{findings.length === 1 ? "" : "s"} · click a row for evidence &amp; remediation
+                </span>
+                {findings.length > 0 && (
+                  <span className="ml-auto flex items-center gap-1">
+                    <span className="font-mono text-[10px] tracking-[0.12em] uppercase text-slate-500 mr-1">Sort</span>
+                    {(["severity", "rule", "file"] as FindSort[]).map((k) => (
+                      <button
+                        key={k}
+                        onClick={() => { setFindSort(k); setExpanded(null); }}
+                        className="font-mono text-[10.5px] rounded px-2.5 py-1 tracking-[0.04em] transition-colors"
+                        style={
+                          findSort === k
+                            ? { background: "rgba(124,58,237,0.15)", border: "1px solid rgba(124,58,237,0.35)", color: "#a78bfa" }
+                            : { background: "none", border: "1px solid transparent", color: "#64748b" }
+                        }
+                      >
+                        {k}
+                      </button>
+                    ))}
+                  </span>
+                )}
+              </div>
+
+              {findings.length === 0 ? (
+                <div className="text-center px-5 py-11">
+                  <svg width="40" height="40" viewBox="0 0 40 40" fill="none" className="mx-auto">
+                    <circle cx="20" cy="20" r="18" stroke="#10b981" strokeOpacity=".4" strokeWidth="1.5" />
+                    <path d="M13 20.5l4.6 4.6L27.5 15" stroke="#10b981" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                  <div className="font-semibold text-emerald-400 text-sm mt-3 mb-1">No findings — clean scan</div>
+                  <p className="text-xs text-slate-500 max-w-[44ch] mx-auto m-0">
+                    All five gate categories passed deterministically. This skill is certified safe for workspace
+                    installation at commit {sha}.
+                  </p>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full border-collapse min-w-[760px]">
+                    <thead>
+                      <tr style={{ background: "rgba(30,41,59,0.5)", borderTop: "1px solid rgba(71,85,105,0.35)", borderBottom: "1px solid rgba(71,85,105,0.35)" }}>
+                        {["Severity", "Rule", "Finding", "Location", "Conf"].map((h) => (
+                          <th key={h} className="px-3.5 py-2.5 text-left font-mono text-[10px] font-semibold tracking-[0.14em] uppercase text-slate-500 whitespace-nowrap">
+                            {h}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sortedFindings.map((f, idx) => (
+                        <React.Fragment key={idx}>
+                          <tr
+                            onClick={() => setExpanded(expanded === idx ? null : idx)}
+                            className="cursor-pointer transition-colors hover:bg-slate-800/40 align-top"
+                            aria-expanded={expanded === idx}
+                            style={{ borderBottom: idx < sortedFindings.length - 1 || expanded === idx ? "1px solid rgba(71,85,105,0.2)" : "none" }}
+                          >
+                            <td className="px-3.5 py-3"><SevPill severity={f.severity} /></td>
+                            <td className="px-3.5 py-3 font-mono text-[11px] whitespace-nowrap">
+                              <span className="text-slate-400">{f.id || f.rule}</span>
+                              {f.id && <><br /><span className="text-slate-500">{f.rule}</span></>}
+                            </td>
+                            <td className="px-3.5 py-3 text-xs text-slate-300 max-w-[380px]">
+                              <span className="line-clamp-2">{f.message}</span>
+                            </td>
+                            <td className="px-3.5 py-3 font-mono text-[10.5px] text-slate-500 whitespace-nowrap tabular-nums">
+                              {f.file}{f.line ? `:${f.line}` : ""}
+                            </td>
+                            <td className="px-3.5 py-3 font-mono text-[10px] tracking-[0.08em] text-slate-500 uppercase">
+                              {f.confidence || "—"}
                             </td>
                           </tr>
-                        )}
-                      </React.Fragment>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </section>
-        )}
+                          {expanded === idx && (f.snippet || f.remediation || f.category) && (
+                            <tr style={{ background: "rgba(8,13,20,0.8)", borderBottom: idx < sortedFindings.length - 1 ? "1px solid rgba(71,85,105,0.2)" : "none" }}>
+                              <td colSpan={5} className="px-4 pt-3 pb-4">
+                                {f.category && (
+                                  <span className="inline-block font-mono text-[9.5px] tracking-[0.1em] uppercase text-slate-500 rounded px-2 py-0.5 mb-2.5" style={{ border: "1px solid rgba(71,85,105,0.35)" }}>
+                                    gate · {CAT_LABEL[f.category] || f.category}
+                                  </span>
+                                )}
+                                {f.remediation && (
+                                  <p className="flex gap-2 items-baseline text-xs text-amber-400 mt-0 mb-2.5">
+                                    <b className="font-mono text-[9.5px] tracking-[0.13em] uppercase flex-shrink-0">Remediation</b>
+                                    <span className="text-slate-300">{f.remediation}</span>
+                                  </p>
+                                )}
+                                {f.snippet && (
+                                  <pre className="m-0 rounded-lg px-3.5 py-3 font-mono text-[11px] text-slate-400 overflow-x-auto leading-relaxed" style={{ background: "#020617", border: "1px solid rgba(71,85,105,0.2)", maxHeight: 150 }}>
+                                    <code>{f.snippet}</code>
+                                  </pre>
+                                )}
+                              </td>
+                            </tr>
+                          )}
+                        </React.Fragment>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
 
-        {/* ── Badge embed ────────────────────────────────────────────── */}
-        {data && (
-          <section className="mb-8">
-            <SectionTitle>Add Badge to Your README</SectionTitle>
-            <GlassCard>
-              <p className="text-xs text-slate-400 mb-4">Display your ScapeGuard security grade directly in your repository README:</p>
-              <div className="flex items-center gap-4 mb-4">
-                <img src={`/api/badge/${owner}/${repo}`} alt={`ScapeGuard Grade ${data.grade}`} className="h-5" />
-                <span className="text-xs text-slate-500">Preview</span>
+            {/* ── Provenance & distribution ─────────────────────────── */}
+            <div className="grid grid-cols-1 md:grid-cols-[minmax(0,5fr)_minmax(0,7fr)] gap-3.5 mt-3.5 mb-14">
+              <div
+                className="rounded-2xl p-5 font-mono text-[11px] leading-[1.9] text-slate-500"
+                style={{ background: "#020617", border: "1px solid rgba(71,85,105,0.25)", boxShadow: "0 10px 40px rgba(0,0,0,0.6)" }}
+              >
+                <div className="flex justify-between items-center pb-2.5 mb-3" style={{ borderBottom: "1px solid rgba(71,85,105,0.2)" }}>
+                  <span className="text-slate-200 font-semibold">scan-report.json</span>
+                  <GradeChip grade={data.grade} />
+                </div>
+                <div className="flex justify-between gap-4"><span>"engine"</span><span style={{ color: "#38bdf8" }}>"scapeguard/2.1.0"</span></div>
+                <div className="flex justify-between gap-4"><span>"grade"</span><span className="font-bold" style={{ color: G.hex }}>"{data.grade}"</span></div>
+                <div className="flex justify-between gap-4"><span>"risk_score"</span><span className="text-amber-500 tabular-nums">{data.risk_score}</span></div>
+                {categories.map((c) => (
+                  <div key={c.category} className="flex justify-between gap-4">
+                    <span>"{c.category}"</span>
+                    <span style={{ color: statusColor(c.status) }}>"{c.status}"</span>
+                  </div>
+                ))}
+                <div className="flex justify-between gap-4"><span>"license"</span><span className="text-slate-200">"{data.license || "Unknown"}"</span></div>
+                <div className="flex justify-between gap-4"><span>"files_scanned"</span><span className="text-emerald-400 tabular-nums">{data.files_analyzed}</span></div>
+                <div className="flex justify-between gap-4"><span>"skill_hash"</span><span>"{sha}"</span></div>
               </div>
-              <div className="flex items-center justify-between gap-3 p-3 rounded-lg font-mono text-[11px] text-slate-400" style={{ background: "rgba(8,13,20,0.8)", border: "1px solid rgba(71,85,105,0.2)" }}>
-                <code className="flex-grow overflow-x-auto">{`[![ScapeGuard Grade ${data.grade}](https://gitscape.ai/api/badge/${owner}/${repo})](${pageUrl})`}</code>
-                <button
-                  onClick={copyBadge}
-                  className="ml-2 flex-shrink-0 px-3 py-1.5 rounded text-[10px] font-bold transition-colors"
-                  style={{
-                    background: copied ? "rgba(16,185,129,0.15)" : "rgba(124,58,237,0.15)",
-                    border: copied ? "1px solid rgba(16,185,129,0.35)" : "1px solid rgba(124,58,237,0.35)",
-                    color: copied ? "#34d399" : "#a78bfa",
-                  }}
-                >
-                  {copied ? "✓ Copied" : "Copy"}
-                </button>
-              </div>
-            </GlassCard>
-          </section>
-        )}
 
-        {/* ── Install command ────────────────────────────────────────── */}
-        {data && (
-          <section className="mb-12">
-            <SectionTitle>Install as Agent Skill</SectionTitle>
-            <GlassCard>
-              <p className="text-xs text-slate-400 mb-3">Run this one command to compile and install this repository as a skill in your AI agent workspace:</p>
-              <div className="flex items-center gap-3 p-3 rounded-lg font-mono text-xs text-slate-300" style={{ background: "rgba(8,13,20,0.8)", border: "1px solid rgba(71,85,105,0.2)" }}>
-                <span className="text-emerald-400 select-none">$</span>
-                <code>npx gitscape {repoUrl}</code>
+              <div className="flex flex-col gap-3.5">
+                <div className="rounded-2xl p-5" style={glassStyle}>
+                  <SectionTitle sub="One command compiles this repository and installs the scanned skill.">
+                    Install as agent skill
+                  </SectionTitle>
+                  <div className="flex items-center gap-3 rounded-lg px-3.5 py-2.5 mt-3 font-mono text-[11.5px] text-slate-300" style={codeSurfaceStyle}>
+                    <span className="text-emerald-400 select-none">$</span>
+                    <code className="flex-1 overflow-x-auto whitespace-nowrap no-scrollbar">{installCmd}</code>
+                    <CopyButton text={installCmd} />
+                  </div>
+                </div>
+                <div className="rounded-2xl p-5" style={glassStyle}>
+                  <SectionTitle sub="Embed the live ScapeGuard badge in your README — it updates on every scan.">
+                    Show your grade
+                  </SectionTitle>
+                  <div className="flex items-center gap-3 mt-3 mb-3">
+                    <img src={`/api/badge/${owner}/${repo}`} alt={`ScapeGuard Grade ${data.grade}`} className="h-5" />
+                    <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-slate-500">live preview</span>
+                  </div>
+                  <div className="flex items-center gap-3 rounded-lg px-3.5 py-2.5 font-mono text-[11px] text-slate-400" style={codeSurfaceStyle}>
+                    <code className="flex-1 overflow-x-auto whitespace-nowrap no-scrollbar">{badgeMarkdown}</code>
+                    <CopyButton text={badgeMarkdown} />
+                  </div>
+                </div>
               </div>
-            </GlassCard>
-          </section>
-        )}
+            </div>
+          </>
+        ) : null}
       </div>
+
+      {/* Page-scoped helpers for the fact pills and micro legends */}
+      <style>{`
+        .fact-pill{
+          display:inline-flex; align-items:center; font-size:11.5px; font-weight:600; color:#94a3b8;
+          background:rgba(30,41,59,0.7); border:1px solid rgba(71,85,105,0.35);
+          border-radius:99px; padding:4px 12px; white-space:nowrap;
+          font-variant-numeric:tabular-nums;
+        }
+        .micro-legend{
+          display:inline-flex; align-items:center; gap:5px;
+          font-family:'JetBrains Mono',ui-monospace,monospace; font-size:9.5px; letter-spacing:.06em;
+          color:#94a3b8; font-variant-numeric:tabular-nums;
+        }
+        .micro-legend i{ width:7px; height:7px; border-radius:2px; display:inline-block; }
+      `}</style>
     </div>
   );
 };

--- a/frontend/components/registryTheme.tsx
+++ b/frontend/components/registryTheme.tsx
@@ -1,0 +1,306 @@
+// Author: Joao Machete
+// Description: Shared visual language for the Public Skill Registry and per-repo
+// security report pages — grade/severity/status palettes, the engraved grade seal,
+// deterministic repo marks, and small chip components. Aurora registry design.
+import React, { useEffect, useRef } from "react";
+
+export interface GradeInfo {
+  hex: string;
+  label: string;
+}
+
+export const GRADE: Record<string, GradeInfo> = {
+  A: { hex: "#10b981", label: "Excellent" },
+  B: { hex: "#84cc16", label: "Good" },
+  C: { hex: "#f59e0b", label: "Moderate" },
+  F: { hex: "#ef4444", label: "High Risk" },
+};
+
+export const gradeInfo = (g?: string): GradeInfo =>
+  GRADE[(g || "").toUpperCase()] ?? { hex: "#64748b", label: "Unknown" };
+
+export const SEV_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"] as const;
+
+export const sevColor = (s?: string): string =>
+  ({
+    CRITICAL: "#ef4444",
+    HIGH: "#f97316",
+    MEDIUM: "#f59e0b",
+    LOW: "#64748b",
+    INFO: "#3b82f6",
+  }[(s || "").toUpperCase()] ?? "#64748b");
+
+export const statusColor = (st?: string): string =>
+  ({ PASS: "#10b981", WARN: "#f59e0b", FAIL: "#ef4444" }[(st || "").toUpperCase()] ?? "#64748b");
+
+export const CAT_LABEL: Record<string, string> = {
+  secrets: "secrets",
+  prompt_injection: "prompt injection",
+  malicious_execution: "malicious execution",
+  supply_chain: "supply chain",
+  excessive_agency: "excessive agency",
+};
+
+export const DEFAULT_CATEGORIES = [
+  "secrets",
+  "prompt_injection",
+  "malicious_execution",
+  "supply_chain",
+  "excessive_agency",
+];
+
+export const fmtK = (n: number): string =>
+  n >= 1000 ? (n / 1000).toFixed(n >= 10000 ? 0 : 1).replace(/\.0$/, "") + "k" : String(n);
+
+const hashStr = (s: string): number => {
+  let h = 2166136261;
+  for (const c of s) {
+    h ^= c.charCodeAt(0);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+};
+
+// Glass panel treatment shared across both registry pages.
+export const glassStyle: React.CSSProperties = {
+  background: "rgba(15,23,42,0.6)",
+  border: "1px solid rgba(71,85,105,0.2)",
+};
+
+export const codeSurfaceStyle: React.CSSProperties = {
+  background: "rgba(8,13,20,0.8)",
+  border: "1px solid rgba(71,85,105,0.2)",
+};
+
+export const Eyebrow: React.FC<{ children: React.ReactNode; className?: string }> = ({ children, className = "" }) => (
+  <span className={`font-mono text-[10px] font-semibold tracking-[0.15em] uppercase text-slate-500 ${className}`}>
+    {children}
+  </span>
+);
+
+export const SectionTitle: React.FC<{ children: React.ReactNode; sub?: string }> = ({ children, sub }) => (
+  <div>
+    <h3 className="text-[13.5px] font-bold text-slate-200 flex items-center gap-2 m-0">
+      <span
+        style={{
+          display: "inline-block",
+          width: 3,
+          height: 15,
+          borderRadius: 2,
+          background: "linear-gradient(#7c3aed, #22d3ee)",
+          flexShrink: 0,
+        }}
+      />
+      {children}
+    </h3>
+    {sub && <p className="text-[11.5px] text-slate-500 mt-1 mb-0">{sub}</p>}
+  </div>
+);
+
+// Deterministic faceted seal tile — the repo's "icon" in grids and ledgers.
+export const RepoMark: React.FC<{ owner: string; repo: string; grade?: string; size?: number }> = ({
+  owner,
+  repo,
+  grade,
+  size = 44,
+}) => {
+  const h = hashStr(`${owner}/${repo}`);
+  const rot = h % 30;
+  const rot2 = (h >> 4) % 45;
+  const ini = ((owner[0] || "?") + (repo[0] || "?")).toUpperCase();
+  const gc = gradeInfo(grade).hex;
+  return (
+    <svg width={size} height={size} viewBox="0 0 44 44" role="img" aria-label={`${owner}/${repo} mark`} style={{ flexShrink: 0 }}>
+      <rect width="44" height="44" rx="9" fill="rgba(30,41,59,0.9)" />
+      <g opacity=".5">
+        <polygon
+          points="22,4 40,22 22,40 4,22"
+          fill="none"
+          stroke={gc}
+          strokeOpacity=".45"
+          strokeWidth="1"
+          transform={`rotate(${rot} 22 22)`}
+        />
+        <polygon
+          points="22,9 35,22 22,35 9,22"
+          fill={gc}
+          fillOpacity=".08"
+          stroke={gc}
+          strokeOpacity=".3"
+          strokeWidth="1"
+          transform={`rotate(${rot2} 22 22)`}
+        />
+      </g>
+      <text
+        x="22"
+        y="27"
+        textAnchor="middle"
+        fontFamily="Inter, system-ui, sans-serif"
+        fontSize="13"
+        fontWeight="700"
+        fill="#e2e8f0"
+        letterSpacing="0.5"
+      >
+        {ini}
+      </text>
+    </svg>
+  );
+};
+
+// Engraved grade seal with tick ring; the large variant animates its arc on mount.
+export const GradeSeal: React.FC<{ grade: string; size?: number; animate?: boolean }> = ({
+  grade,
+  size = 40,
+  animate = false,
+}) => {
+  const arcRef = useRef<SVGCircleElement>(null);
+  const G = gradeInfo(grade);
+  const R = size / 2;
+  const ringR = R - 4;
+  const tickR1 = R - 1;
+  const tickR0 = R - 3.2;
+  const tickN = size >= 100 ? 48 : 24;
+  const scoreMap: Record<string, number> = { A: 0.97, B: 0.75, C: 0.52, F: 0.18 };
+  const circ = 2 * Math.PI * ringR;
+  const off = circ * (1 - (scoreMap[grade] ?? 0));
+  const fs = Math.round(size * 0.33);
+
+  useEffect(() => {
+    if (!animate || !arcRef.current) return;
+    const el = arcRef.current;
+    el.style.transition = "none";
+    el.style.strokeDashoffset = String(circ);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        el.style.transition = "stroke-dashoffset 1.2s cubic-bezier(0.4,0,0.2,1)";
+        el.style.strokeDashoffset = String(off);
+      });
+    });
+  }, [animate, grade, circ, off]);
+
+  const ticks = [];
+  for (let i = 0; i < tickN; i++) {
+    const a = (i / tickN) * Math.PI * 2;
+    ticks.push(
+      <line
+        key={i}
+        x1={R + Math.cos(a) * tickR0}
+        y1={R + Math.sin(a) * tickR0}
+        x2={R + Math.cos(a) * tickR1}
+        y2={R + Math.sin(a) * tickR1}
+        stroke={G.hex}
+        strokeOpacity=".5"
+        strokeWidth="1"
+      />
+    );
+  }
+
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} role="img" aria-label={`Grade ${grade}`} style={{ flexShrink: 0 }}>
+      {animate && (
+        <defs>
+          <filter id="seal-glow">
+            <feGaussianBlur stdDeviation="3" result="coloredBlur" />
+            <feMerge>
+              <feMergeNode in="coloredBlur" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
+      )}
+      {ticks}
+      <circle cx={R} cy={R} r={ringR} fill="none" stroke="rgba(71,85,105,.25)" strokeWidth="3" />
+      <circle
+        ref={arcRef}
+        cx={R}
+        cy={R}
+        r={ringR}
+        fill="none"
+        stroke={G.hex}
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeDasharray={circ}
+        strokeDashoffset={animate ? circ : off}
+        transform={`rotate(-90 ${R} ${R})`}
+        filter={animate ? "url(#seal-glow)" : undefined}
+      />
+      <circle cx={R} cy={R} r={ringR - 7} fill={G.hex} fillOpacity=".07" />
+      <text
+        x={R}
+        y={R + fs * 0.36}
+        textAnchor="middle"
+        fontFamily="Inter, system-ui, sans-serif"
+        fontSize={fs}
+        fontWeight="800"
+        fill={G.hex}
+      >
+        {grade}
+      </text>
+    </svg>
+  );
+};
+
+export const GradeChip: React.FC<{ grade: string }> = ({ grade }) => {
+  const G = gradeInfo(grade);
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 font-mono text-[10.5px] font-bold tracking-[0.08em] rounded-full px-2.5 py-0.5 whitespace-nowrap"
+      style={{ color: G.hex, border: `1px solid ${G.hex}55`, background: `${G.hex}14` }}
+    >
+      {grade} · {G.label.toUpperCase()}
+    </span>
+  );
+};
+
+export const StatusChip: React.FC<{ status: string; size?: number }> = ({ status, size = 10.5 }) => {
+  const c = statusColor(status);
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 font-mono font-bold tracking-[0.12em] rounded-full px-3 py-1"
+      style={{ color: c, border: `1px solid ${c}`, fontSize: size }}
+    >
+      <i style={{ width: 7, height: 7, borderRadius: "50%", background: c, display: "inline-block" }} />
+      {(status || "").toUpperCase()}
+    </span>
+  );
+};
+
+export const SevPill: React.FC<{ severity: string }> = ({ severity }) => {
+  const c = sevColor(severity);
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 font-mono text-[9.5px] font-bold tracking-[0.1em] rounded px-1.5 py-0.5 whitespace-nowrap"
+      style={{ color: c, border: `1px solid ${c}` }}
+    >
+      <i style={{ width: 6, height: 6, borderRadius: "50%", background: c, display: "inline-block" }} />
+      {(severity || "").toUpperCase()}
+    </span>
+  );
+};
+
+// Copy-to-clipboard button with transient confirmation, used across both pages.
+export const CopyButton: React.FC<{ text: string; className?: string }> = ({ text, className = "" }) => {
+  const [copied, setCopied] = React.useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      /* clipboard unavailable — leave button state unchanged */
+    }
+  };
+  return (
+    <button
+      onClick={copy}
+      className={`flex-shrink-0 font-mono text-[10px] font-bold tracking-[0.08em] rounded px-2.5 py-1.5 transition-colors ${className}`}
+      style={
+        copied
+          ? { background: "rgba(16,185,129,0.15)", border: "1px solid rgba(16,185,129,0.45)", color: "#34d399" }
+          : { background: "rgba(6,182,212,0.12)", border: "1px solid rgba(6,182,212,0.4)", color: "#67e8f9" }
+      }
+    >
+      {copied ? "✓ COPIED" : "COPY"}
+    </button>
+  );
+};


### PR DESCRIPTION
## Summary

Full redesign of the Public Agent Skill Registry and the per-repo security audit pages, in the site's existing visual language (Inter + JetBrains Mono, slate glass cards, cyan/violet accents).

**Registry index (`/registry`)** — now a full-bleed page with its own hero band:
- Registry pulse strip computed live from `/api/registry/search`: skills indexed, gate pass rate, median risk, open findings, grade-distribution bar
- Grade filter chips (All/A/B/C/F with counts), four sort orders, and a grid ⇄ list toggle
- Grid cards: deterministic seal-mark icon, grade seal, PASS/WARN/FAIL verdict + findings count, risk micro-bar
- List view: condensed 5-column ledger (#, skill w/ description subtitle, language, risk, grade) — no horizontal scroll
- Pasting a GitHub URL enables **Compile & Scan**, routing to the report page which compiles on the fly

**Report dashboard (`/registry/:owner/:repo`)**
- Certificate-of-audit card: animated engraved grade seal with glow, verdict chip, engine/commit/gates metadata, grade bands
- KPI tiles: risk score on a 0–100 scale with B/C threshold ticks, findings with severity-stacked micro-bar, coverage
- Gate categories panel (real `categories` from the API, grade-derived fallback preserved) and severity profile chart
- Sortable findings ledger with expandable rows: category, remediation, code snippet
- Provenance section: scan-report.json card, install command, README badge embed — all with copy buttons
- Existing SEO title/meta behavior preserved

**Shared** — new `frontend/components/registryTheme.tsx`: grade/severity/status palettes, GradeSeal, RepoMark, chips, CopyButton. Grade and severity colors are always paired with a text label, never color alone.

## Notes
- Risk-trend chart from the design proposal is deliberately omitted: the backend does not persist scan history yet (would need a small addition to `registry_store.py`)
- Cards show verdict + findings count instead of per-category gate dots, since the search endpoint does not return categories

## Test plan
- [x] `tsc --noEmit` — zero errors in touched files (pre-existing errors in Diagram/DevTools untouched)
- [x] `vite build` succeeds
- [x] SSR smoke test (esbuild + renderToString) renders both pages and all theme components
- [ ] Manual pass with `npm run dev` + backend on 8081: grid/list toggle, filters, card → report navigation, findings expansion, copy buttons